### PR TITLE
Replace alpine base docker image with ubuntu

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,21 @@
-
-FROM golang:1.18-alpine3.16 AS builder
+FROM ubuntu:22.04 AS builder
+RUN apt-get update && \
+    apt-get install -y \
+      build-essential \
+      ca-certificates \
+      golang \
+      golang-1.18
 ADD ./catcher ./catcher
 ADD ./relay ./relay
 ADD ./go.mod .
 ADD ./go.sum .
 ADD ./Makefile .
-RUN apk add --update make build-base git binutils-gold
 RUN set -ex && \
-    unset GOPATH && \
 	make
 
-FROM alpine
-RUN apk add --update ca-certificates
-COPY --from=builder /go/dist /dist
+FROM ubuntu:22.04
+RUN apt-get update && \
+    apt-get install -y \
+      ca-certificates
+COPY --from=builder /dist /dist
 ENTRYPOINT [ "/dist/relay" ]


### PR DESCRIPTION
At some point between the last time we published a docker image for this project and now, the Go `plugin` package became incompatible with musl. Just importing the package causes the relay to segfault; this happens even if we don't actually attempt to load any plugins. (Presumably the initialization of some global variable is the cause.) This happens even with `libc6-compat` installed, alas.

I don't think it's worth debugging this further. Let's just use ubuntu as the base image instead, so that we're using glibc and not musl. This fixes the problem immediately. While this does increase the size of the Docker image, as you might expect (we go from 62MB to 154MB), and that's not ideal, I don't think this is problematic as a near term solution. Longer term, we can switch to another implementation strategy for the plugins and switch back to alpine.