### PR TITLE
Add content blocker plugin

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,15 @@
+name: Test
+on: push
+defaults:
+  run:
+    shell: bash
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@master
+      - name: Set up go
+        uses: actions/setup-go@master
+      - name: Run tests
+        run: make test

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ plugins:
 	mkdir -p $(DIST_PATH)/plugins/traffic/active
 	mkdir -p $(DIST_PATH)/plugins/traffic/inactive
 	go build -buildmode=plugin -o $(PLUGIN_DIST_PATH)/active/010-paths.so $(RELAY_MODULE)/relay/plugins/traffic/paths-plugin/main
+	go build -buildmode=plugin -o $(PLUGIN_DIST_PATH)/active/015-paths.so $(RELAY_MODULE)/relay/plugins/traffic/content-blocker-plugin/main
 	go build -buildmode=plugin -o $(PLUGIN_DIST_PATH)/active/020-relay.so $(RELAY_MODULE)/relay/plugins/traffic/relay-plugin/main
 	go build -buildmode=plugin -o $(PLUGIN_DIST_PATH)/active/030-logging.so $(RELAY_MODULE)/relay/plugins/traffic/logging-plugin/main
 

--- a/relay/plugins/traffic/content-blocker-plugin/content-blocker-plugin.go
+++ b/relay/plugins/traffic/content-blocker-plugin/content-blocker-plugin.go
@@ -1,0 +1,296 @@
+// The Content-Blocker plugin blocks content matching a regular expression from
+// incoming request bodies and headers. It's controlled by four environment
+// variables:
+//
+// - TRAFFIC_EXCLUDE_BODY_CONTENT: If set, a regular expression that will be
+// evaluated against request bodies. Matching content will be completely deleted
+// from the request.
+// - TRAFFIC_MASK_BODY_CONTENT: If set, a regular expression that will be
+// evaluated against request bodies. Matching content will be replaced with
+// asterisks.
+// - TRAFFIC_EXCLUDE_HEADER_CONTENT: Like TRAFFIC_EXCLUDE_BODY_CONTENT, but
+// applies to header values.
+// - TRAFFIC_MASK_HEADER_CONTENT: Like TRAFFIC_MASK_BODY_CONTENT, but applies to
+// header values.
+//
+// Although EXCLUDE is more thorough, MASK has two benefits:
+//
+// - It makes it more clear that something was blocked.
+// - It does not change the positions of characters, which makes it less likely
+// to interfere with deserialization of the request body when complex encodings
+// are used.
+//
+// Whether these benefits are more important than the thoroughness of EXCLUDE
+// will depend on the application.
+//
+// It's important to understand that this plugin does not understand the format
+// of the requests it processes; it simply treats the entire request body as
+// text. This makes it robust to request format changes, but it also means that
+// using a regular expression that matches JSON, HTML, or CSS syntax may corrupt
+// the request, so be careful.
+//
+// Because this plugin transforms requests, it must run before the relay plugin.
+package content_blocker_plugin
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"os"
+	"regexp"
+	"strconv"
+
+	"github.com/fullstorydev/relay-core/relay/plugins/traffic"
+)
+
+var (
+	Factory    contentBlockerPluginFactory
+	logger     = log.New(os.Stdout, "[traffic-content-blocker] ", 0)
+	pluginName = "Content-Blocker"
+
+	excludeBodyContentVar   = "TRAFFIC_EXCLUDE_BODY_CONTENT"   // A go regexp string or empty
+	maskBodyContentVar      = "TRAFFIC_MASK_BODY_CONTENT"      // A go regexp string or empty
+	excludeHeaderContentVar = "TRAFFIC_EXCLUDE_HEADER_CONTENT" // A go regexp string or empty
+	maskHeaderContentVar    = "TRAFFIC_MASK_HEADER_CONTENT"    // A go regexp string or empty
+)
+
+type contentBlockerPluginFactory struct{}
+
+func (f contentBlockerPluginFactory) Name() string {
+	return pluginName
+}
+
+func (f contentBlockerPluginFactory) ConfigVars() map[string]bool {
+	return map[string]bool{
+		excludeBodyContentVar:   false,
+		maskBodyContentVar:      false,
+		excludeHeaderContentVar: false,
+		maskHeaderContentVar:    false,
+	}
+}
+
+func (f contentBlockerPluginFactory) New(env map[string]string) (traffic.Plugin, error) {
+	bodyBlockers, err := newContentBlockerList(
+		env,
+		"body",
+		excludeBodyContentVar,
+		maskBodyContentVar,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	headerBlockers, err := newContentBlockerList(
+		env,
+		"header",
+		excludeHeaderContentVar,
+		maskHeaderContentVar,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(bodyBlockers) == 0 && len(headerBlockers) == 0 {
+		return nil, nil
+	}
+
+	return &contentBlockerPlugin{
+		bodyBlockers:   bodyBlockers,
+		headerBlockers: headerBlockers,
+	}, nil
+}
+
+type contentBlockerPlugin struct {
+	bodyBlockers   []*contentBlocker
+	headerBlockers []*contentBlocker
+}
+
+func (plug contentBlockerPlugin) Name() string {
+	return pluginName
+}
+
+func (plug contentBlockerPlugin) HandleRequest(response http.ResponseWriter, request *http.Request, serviced bool) bool {
+	if serviced := plug.blockHeaderContent(response, request); serviced {
+		return true
+	}
+	if serviced := plug.blockBodyContent(response, request); serviced {
+		return true
+	}
+	return false
+}
+
+func (plug contentBlockerPlugin) blockHeaderContent(response http.ResponseWriter, request *http.Request) bool {
+	if len(plug.headerBlockers) == 0 {
+		return false
+	}
+
+	for _, headerValues := range request.Header {
+		for i, headerValue := range headerValues {
+			processedValue := []byte(headerValue)
+			for _, blocker := range plug.headerBlockers {
+				processedValue = blocker.Block(processedValue)
+			}
+			headerValues[i] = string(processedValue)
+		}
+	}
+
+	return false
+}
+
+func (plug contentBlockerPlugin) blockBodyContent(response http.ResponseWriter, request *http.Request) bool {
+	if len(plug.bodyBlockers) == 0 {
+		return false
+	}
+
+	// Block all websocket connections if we're blocking body content.
+	// TODO(sethf): This is necessary because the current plugin architecture
+	// doesn't give us a hook that would allow us to handle websocket messages,
+	// so we wouldn't be able to actually do any blocking. The safest thing to
+	// do for now is to fail closed. In the short term, this won't do any harm,
+	// because we don't actually need to support websockets, but if that changes
+	// we'll need to revisit this.
+	if len(plug.bodyBlockers) > 0 && request.Header.Get("Upgrade") == "websocket" {
+		logger.Println("Rejecting websocket connection (content blocking is not supported with websockets):", request.URL)
+		http.Error(response, fmt.Sprintf("Blocking unsupported websocket connection: %v", request.URL), 500)
+		return true
+	}
+
+	if request.Body == nil || request.Body == http.NoBody {
+		return false
+	}
+
+	processedBody, err := ioutil.ReadAll(request.Body)
+	if err != nil {
+		http.Error(response, fmt.Sprintf("Error reading request body: %s", err), 500)
+		request.Body = http.NoBody
+		return true
+	}
+	initialLength := len(processedBody)
+
+	for _, blocker := range plug.bodyBlockers {
+		processedBody = blocker.Block(processedBody)
+	}
+
+	// If the length of the body has changed, we should update the
+	// Content-Length header too.
+	finalLength := len(processedBody)
+	if finalLength != initialLength {
+		contentLength := int64(finalLength)
+		request.ContentLength = contentLength
+		request.Header.Set("Content-Length", strconv.FormatInt(contentLength, 10))
+	}
+
+	request.Body = ioutil.NopCloser(bytes.NewBuffer(processedBody))
+	return false
+}
+
+type contentBlockerMode int64
+
+const (
+	maskMode contentBlockerMode = iota
+	excludeMode
+)
+
+func (mode contentBlockerMode) String() string {
+	switch mode {
+	case maskMode:
+		return "mask"
+	case excludeMode:
+		return "exclude"
+	default:
+		return "(unknown mode)"
+	}
+}
+
+// newContentBlockerList is a helper that creates a group of related
+// contentBlocker instances as a single operation.
+func newContentBlockerList(
+	env map[string]string,
+	listName string,
+	excludeVar string,
+	maskVar string,
+) ([]*contentBlocker, error) {
+	var blockers []*contentBlocker
+
+	if blocker, err := newContentBlocker(env, excludeVar, excludeMode); err != nil {
+		return nil, err
+	} else if blocker != nil {
+		blockers = append(blockers, blocker)
+	}
+
+	if blocker, err := newContentBlocker(env, maskVar, maskMode); err != nil {
+		return nil, err
+	} else if blocker != nil {
+		blockers = append(blockers, blocker)
+	}
+
+	for _, blocker := range blockers {
+		logger.Printf("Content-blocker plugin will %s %s content matching \"%s\"", blocker.mode, listName, blocker.regexp)
+	}
+
+	return blockers, nil
+}
+
+var maskSymbol = []byte("*")
+
+// contentBlocker applies a content blocking transformation (either exclude or
+// mask) to content that matches a regular expression.
+type contentBlocker struct {
+	mode   contentBlockerMode
+	regexp *regexp.Regexp
+}
+
+func newContentBlocker(
+	env map[string]string,
+	varName string,
+	mode contentBlockerMode,
+) (*contentBlocker, error) {
+	pattern := env[varName]
+	if pattern == "" {
+		return nil, nil
+	}
+
+	regexp, err := regexp.Compile(pattern)
+	if err != nil {
+		return nil, fmt.Errorf("Could not compile %v regular expression: %v", varName, err)
+	}
+
+	return &contentBlocker{
+		mode:   mode,
+		regexp: regexp,
+	}, nil
+}
+
+func (b *contentBlocker) Block(content []byte) []byte {
+	switch b.mode {
+	case maskMode:
+		return b.regexp.ReplaceAllFunc(content, func(matched []byte) []byte {
+			return bytes.Repeat(maskSymbol, len(matched))
+		})
+	case excludeMode:
+		return b.regexp.ReplaceAllLiteral(content, []byte{})
+	default:
+		panic(fmt.Errorf("Invalid content blocking mode: %v", b.mode))
+	}
+}
+
+/*
+Copyright 2022 FullStory, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+and associated documentation files (the "Software"), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge, publish, distribute,
+sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or
+substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/

--- a/relay/plugins/traffic/content-blocker-plugin/content-blocker-plugin.go
+++ b/relay/plugins/traffic/content-blocker-plugin/content-blocker-plugin.go
@@ -50,6 +50,9 @@ var (
 	logger     = log.New(os.Stdout, "[traffic-content-blocker] ", 0)
 	pluginName = "Content-Blocker"
 
+	PluginVersionHeaderName = "X-Relay-Content-Blocker-Version"
+	PluginVersion           = "v0.1.3"
+
 	excludeBodyContentVar   = "TRAFFIC_EXCLUDE_BODY_CONTENT"   // A go regexp string or empty
 	maskBodyContentVar      = "TRAFFIC_MASK_BODY_CONTENT"      // A go regexp string or empty
 	excludeHeaderContentVar = "TRAFFIC_EXCLUDE_HEADER_CONTENT" // A go regexp string or empty
@@ -118,6 +121,10 @@ func (plug contentBlockerPlugin) HandleRequest(response http.ResponseWriter, req
 	if serviced := plug.blockBodyContent(response, request); serviced {
 		return true
 	}
+
+	// Tag the request with a header for debugging purposes.
+	request.Header.Add(PluginVersionHeaderName, PluginVersion)
+
 	return false
 }
 

--- a/relay/plugins/traffic/content-blocker-plugin/content-blocker-plugin_test.go
+++ b/relay/plugins/traffic/content-blocker-plugin/content-blocker-plugin_test.go
@@ -1,0 +1,250 @@
+package content_blocker_plugin_test
+
+import (
+	"bytes"
+	"net/http"
+	"strconv"
+	"testing"
+
+	"github.com/fullstorydev/relay-core/catcher"
+	"github.com/fullstorydev/relay-core/relay"
+	"github.com/fullstorydev/relay-core/relay/commands"
+	"github.com/fullstorydev/relay-core/relay/plugins/traffic/content-blocker-plugin"
+	"github.com/fullstorydev/relay-core/relay/test"
+)
+
+func TestContentBlockerBlocksContent(t *testing.T) {
+	testCases := []contentBlockerTestCase{
+		{
+			desc: "Body content can be excluded",
+			env: commands.Environment{
+				"TRAFFIC_EXCLUDE_BODY_CONTENT": `[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+`,
+			},
+			originalBody: `{ "content": "Excluded IP address = 215.1.0.335." }`,
+			expectedBody: `{ "content": "Excluded IP address = ." }`,
+		},
+		{
+			desc: "Body content can be masked",
+			env: commands.Environment{
+				"TRAFFIC_MASK_BODY_CONTENT": `[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+`,
+			},
+			originalBody: `{ "content": "Excluded IP address = 215.1.0.335." }`,
+			expectedBody: `{ "content": "Excluded IP address = ***********." }`,
+		},
+		{
+			desc: "Header content can be excluded",
+			env: commands.Environment{
+				"TRAFFIC_EXCLUDE_HEADER_CONTENT": `[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+`,
+			},
+			originalHeaders: map[string]string{
+				"X-Forwarded-For": "foo.com,192.168.0.1,bar.com",
+			},
+			expectedHeaders: map[string]string{
+				"X-Forwarded-For": "foo.com,,bar.com",
+			},
+		},
+		{
+			desc: "Header content can be masked",
+			env: commands.Environment{
+				"TRAFFIC_MASK_HEADER_CONTENT": `[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+`,
+			},
+			originalHeaders: map[string]string{
+				"X-Forwarded-For": "foo.com,192.168.0.1,bar.com",
+			},
+			expectedHeaders: map[string]string{
+				"X-Forwarded-For": "foo.com,***********,bar.com",
+			},
+		},
+		{
+			desc: "Header values are blocked but header names are not",
+			env: commands.Environment{
+				"TRAFFIC_EXCLUDE_HEADER_CONTENT": `(?i)BAR`,
+				"TRAFFIC_MASK_HEADER_CONTENT":    `(?i)FOO`,
+			},
+			originalHeaders: map[string]string{
+				"X-Barrier":  "foo bar baz",
+				"X-Football": "foo bar baz",
+			},
+			expectedHeaders: map[string]string{
+				"X-Barrier":  "***  baz",
+				"X-Football": "***  baz",
+			},
+		},
+		{
+			desc: "Exclusion takes priority over masking",
+			env: commands.Environment{
+				"TRAFFIC_EXCLUDE_BODY_CONTENT": `[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+`,
+				"TRAFFIC_MASK_BODY_CONTENT":    `[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+`,
+			},
+			originalBody: `{ "content": "Excluded IP address = 215.1.0.335." }`,
+			expectedBody: `{ "content": "Excluded IP address = ." }`,
+		},
+		{
+			desc: "Complex configurations are supported",
+			env: commands.Environment{
+				"TRAFFIC_EXCLUDE_BODY_CONTENT":   `(?i)EXCLUDED`,
+				"TRAFFIC_MASK_BODY_CONTENT":      `[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+`,
+				"TRAFFIC_EXCLUDE_HEADER_CONTENT": `(?i)DELETED`,
+				"TRAFFIC_MASK_HEADER_CONTENT":    `(foo|bar)`,
+			},
+			originalBody: `{ "content": "Excluded, deleted foo bar IP address = 215.1.0.335." }`,
+			expectedBody: `{ "content": ", deleted foo bar IP address = ***********." }`,
+			originalHeaders: map[string]string{
+				"X-Forwarded-For":  "192.168.0.1",
+				"X-Headerfoobar":   "bar foo baz bar baz foobar",
+				"X-Special-Header": "Some EXCLUDED, DELETED content",
+			},
+			expectedHeaders: map[string]string{
+				"X-Forwarded-For":  "192.168.0.1",
+				"X-Headerfoobar":   "*** *** baz *** baz ******",
+				"X-Special-Header": "Some EXCLUDED,  content",
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		runContentBlockerTest(t, testCase)
+	}
+}
+
+func TestContentBlockerBlocksWebsockets(t *testing.T) {
+	env := commands.Environment{
+		"TRAFFIC_MASK_BODY_CONTENT": `[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+`,
+	}
+	plugins := map[string]bool{
+		content_blocker_plugin.Factory.Name(): true,
+	}
+
+	test.WithCatcherAndRelay(t, env, plugins, func(catcherService *catcher.Service, relayService *relay.Service) {
+		request, err := http.NewRequest(
+			"POST",
+			relayService.HttpUrl(),
+			bytes.NewBufferString(`{ "content": "192.168.0.1" }`),
+		)
+		if err != nil {
+			t.Errorf("Error creating request: %v", err)
+			return
+		}
+
+		request.Header.Set("Content-Type", "application/json")
+		request.Header.Set("Upgrade", "websocket")
+
+		response, err := http.DefaultClient.Do(request)
+		if err != nil {
+			t.Errorf("Error POSTing: %v", err)
+			return
+		}
+		defer response.Body.Close()
+
+		// This plugin doesn't support websockets, so we should fail closed and
+		// the attempt to establish a websocket connection should fail.
+		if response.StatusCode != 500 {
+			t.Errorf("Expected 500 response: %v", response)
+			return
+		}
+	})
+}
+
+type contentBlockerTestCase struct {
+	desc            string
+	env             commands.Environment
+	originalBody    string
+	expectedBody    string
+	originalHeaders map[string]string
+	expectedHeaders map[string]string
+}
+
+func runContentBlockerTest(t *testing.T, testCase contentBlockerTestCase) {
+	plugins := map[string]bool{
+		content_blocker_plugin.Factory.Name(): true,
+	}
+
+	originalHeaders := testCase.originalHeaders
+	if originalHeaders == nil {
+		originalHeaders = make(map[string]string)
+	}
+
+	expectedHeaders := testCase.expectedHeaders
+	if expectedHeaders == nil {
+		expectedHeaders = make(map[string]string)
+	}
+
+	test.WithCatcherAndRelay(t, testCase.env, plugins, func(catcherService *catcher.Service, relayService *relay.Service) {
+		request, err := http.NewRequest(
+			"POST",
+			relayService.HttpUrl(),
+			bytes.NewBufferString(testCase.originalBody),
+		)
+		if err != nil {
+			t.Errorf("Test '%v': Error creating request: %v", testCase.desc, err)
+			return
+		}
+
+		request.Header.Set("Content-Type", "application/json")
+		for header, headerValue := range originalHeaders {
+			request.Header.Set(header, headerValue)
+		}
+
+		response, err := http.DefaultClient.Do(request)
+		if err != nil {
+			t.Errorf("Test '%v': Error POSTing: %v", testCase.desc, err)
+			return
+		}
+		defer response.Body.Close()
+
+		if response.StatusCode != 200 {
+			t.Errorf("Test '%v': Expected 200 response: %v", testCase.desc, response)
+			return
+		}
+
+		lastRequest, err := catcherService.LastRequest()
+		if err != nil {
+			t.Errorf("Test '%v': Error reading last request from catcher: %v", testCase.desc, err)
+			return
+		}
+
+		for expectedHeader, expectedHeaderValue := range expectedHeaders {
+			actualHeaderValue := lastRequest.Header.Get(expectedHeader)
+			if expectedHeaderValue != actualHeaderValue {
+				t.Errorf(
+					"Test '%v': Expected header '%v' with value '%v' but got: %v",
+					testCase.desc,
+					expectedHeader,
+					expectedHeaderValue,
+					actualHeaderValue,
+				)
+			}
+		}
+
+		lastRequestBody, err := catcherService.LastRequestBody()
+		if err != nil {
+			t.Errorf("Test '%v': Error reading last request body from catcher: %v", testCase.desc, err)
+			return
+		}
+
+		lastRequestBodyStr := string(lastRequestBody)
+		if testCase.expectedBody != lastRequestBodyStr {
+			t.Errorf(
+				"Test '%v': Expected body '%v' but got: %v",
+				testCase.desc,
+				testCase.expectedBody,
+				lastRequestBodyStr,
+			)
+		}
+
+		contentLength, err := strconv.Atoi(lastRequest.Header.Get("Content-Length"))
+		if err != nil {
+			t.Errorf("Test '%v': Error parsing Content-Length: %v", testCase.desc, err)
+			return
+		}
+
+		if contentLength != len(lastRequestBody) {
+			t.Errorf(
+				"Test '%v': Content-Length is %v but actual body length is %v",
+				testCase.desc,
+				contentLength,
+				len(lastRequestBody),
+			)
+		}
+	})
+}

--- a/relay/plugins/traffic/content-blocker-plugin/content-blocker-plugin_test.go
+++ b/relay/plugins/traffic/content-blocker-plugin/content-blocker-plugin_test.go
@@ -169,6 +169,8 @@ func runContentBlockerTest(t *testing.T, testCase contentBlockerTestCase) {
 		expectedHeaders = make(map[string]string)
 	}
 
+	expectedHeaders[content_blocker_plugin.PluginVersionHeaderName] = content_blocker_plugin.PluginVersion
+
 	test.WithCatcherAndRelay(t, testCase.env, plugins, func(catcherService *catcher.Service, relayService *relay.Service) {
 		request, err := http.NewRequest(
 			"POST",

--- a/relay/plugins/traffic/content-blocker-plugin/main/main.go
+++ b/relay/plugins/traffic/content-blocker-plugin/main/main.go
@@ -1,0 +1,7 @@
+package main
+
+import (
+	"github.com/fullstorydev/relay-core/relay/plugins/traffic/content-blocker-plugin"
+)
+
+var Factory = content_blocker_plugin.Factory


### PR DESCRIPTION
This PR adds a new Content-Blocker relay plugin that allows customers to exclude or mask content from incoming requests based on regular expression patterns. See the comment at the top of `content-blocker-plugin.go` for more details on how it works.

This feature allows you to ensure that certain kinds of data never get sent to FullStory. While it's restricted to blocking data that can be reliably identified using a regular expression, there are a number of real world situations where that's useful - consider, for example, bitcoin wallet addresses. Whenever possible, this kind of data should be blocked using other privacy mechanisms, but this plugin allows the relay to serve as an additional layer of defense if those mechanisms fail. The blocked data never reaches FullStory's servers; it's either deleted entirely or replaced with asterisks, depending on whether exclusion or masking was used.