### PR TITLE
Simplify plugin architecture

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,25 +1,14 @@
 export PROJECT_HOME := $(shell pwd)
 export DIST_PATH     := $(PROJECT_HOME)/dist
-export PLUGIN_DIST_PATH := $(DIST_PATH)/plugins/traffic
 export RELAY_MODULE := github.com/fullstorydev/relay-core
 
-.PHONY: all plugins cli compile test clean
+.PHONY: all compile test clean
 
 all: compile
 
-plugins:
-	mkdir -p $(DIST_PATH)/plugins/traffic/active
-	mkdir -p $(DIST_PATH)/plugins/traffic/inactive
-	go build -buildmode=plugin -o $(PLUGIN_DIST_PATH)/active/010-paths.so $(RELAY_MODULE)/relay/plugins/traffic/paths-plugin/main
-	go build -buildmode=plugin -o $(PLUGIN_DIST_PATH)/active/015-paths.so $(RELAY_MODULE)/relay/plugins/traffic/content-blocker-plugin/main
-	go build -buildmode=plugin -o $(PLUGIN_DIST_PATH)/active/020-relay.so $(RELAY_MODULE)/relay/plugins/traffic/relay-plugin/main
-	go build -buildmode=plugin -o $(PLUGIN_DIST_PATH)/active/030-logging.so $(RELAY_MODULE)/relay/plugins/traffic/logging-plugin/main
-
-cli:
+compile:
 	go build -o $(DIST_PATH)/relay $(RELAY_MODULE)/relay/main
 	go build -o $(DIST_PATH)/catcher $(RELAY_MODULE)/catcher/main
-
-compile: plugins cli
 
 test: compile
 	go test -v $(RELAY_MODULE)/...

--- a/relay/plugins/plugins.go
+++ b/relay/plugins/plugins.go
@@ -1,156 +1,52 @@
 package plugins
 
 import (
-	"errors"
 	"fmt"
 	"log"
 	"os"
-	"path"
-	"path/filepath"
-	"plugin"
 
 	"github.com/fullstorydev/relay-core/relay/commands"
 	"github.com/fullstorydev/relay-core/relay/plugins/traffic"
+	"github.com/fullstorydev/relay-core/relay/plugins/traffic/content-blocker-plugin"
+	"github.com/fullstorydev/relay-core/relay/plugins/traffic/logging-plugin"
+	"github.com/fullstorydev/relay-core/relay/plugins/traffic/paths-plugin"
+	"github.com/fullstorydev/relay-core/relay/plugins/traffic/relay-plugin"
 )
 
 var logger = log.New(os.Stdout, "[plugin] ", 0)
 
-const PluginDirActiveTrafficPath = "/traffic/active"
-
-// Plugins loads, configures, and manages dynamically loaded plugins. Most relay
-// functionality is implemented via these plugins.
-//
-// The usual flow is to load the plugins via Load() or LoadWithFilter(),
-// configure them via SetupEnvironment() or ConfigurePlugins(), and then
-// construct the relay Service using the fully-configured Plugins instance. See
-// the documentation of each method for more details about when to use them.
-type Plugins struct {
-	Factories []traffic.PluginFactory
-	Traffic   []traffic.Plugin
+// The default set of traffic plugins.
+var Default = []traffic.PluginFactory{
+	paths_plugin.Factory,
+	content_blocker_plugin.Factory,
+	relay_plugin.Factory,
+	logging_plugin.Factory,
 }
 
-func New() *Plugins {
-	return &Plugins{}
-}
+// Load creates and configures a set of plugins. Most relay functionality
+// is implemented via these plugins.
+func Load(
+	pluginFactories []traffic.PluginFactory,
+	envProvider commands.EnvironmentProvider,
+) ([]traffic.Plugin, error) {
+	trafficPlugins := []traffic.Plugin{}
 
-// Load loads all available plugins in the provided directory.
-func (plugins *Plugins) Load(dirPath string) error {
-	return plugins.LoadWithFilter(dirPath, nil)
-}
+	for _, factory := range pluginFactories {
+		logger.Printf("Loading plugin: %s\n", factory.Name())
 
-// LoadWithFilter loads plugins from the provided directory if they're present
-// in the provided allowlist. The allowlist is a set where the keys are values
-// returned from traffic.PluginFactory#Name().
-func (plugins *Plugins) LoadWithFilter(dirPath string, pluginAllowlist map[string]bool) error {
-	// Load traffic plugins
-	activeTrafficPath := path.Join(dirPath, PluginDirActiveTrafficPath)
-	soNames, err := readSharedObjectNames(activeTrafficPath)
-	if err != nil {
-		return err
-	}
-	for _, soName := range soNames {
-		err = plugins.loadTrafficPlugin(soName, pluginAllowlist)
+		plugin, err := factory.New(envProvider)
 		if err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-// TrafficEnvVars returns a list of the configuration variables each loaded
-// plugin uses.
-func (plugins *Plugins) TrafficEnvVars() []commands.EnvVar {
-	vars := []commands.EnvVar{}
-	for _, trafficPluginFactory := range plugins.Factories {
-		for name, required := range trafficPluginFactory.ConfigVars() {
-			vars = append(vars, commands.EnvVar{
-				EnvKey:     name,
-				Required:   required,
-				DefaultVal: "",
-				IsDir:      false,
-			})
-		}
-	}
-	return vars
-}
-
-// SetupEnvironment configures the loaded plugins. It reads configuration
-// variables from the environment and from any .env file that may be present.
-func (plugins *Plugins) SetupEnvironment() (commands.Environment, error) {
-	vars := plugins.TrafficEnvVars()
-
-	env, err := commands.GetEnvironment(vars)
-	if err != nil {
-		return env, err
-	}
-
-	if err := plugins.ConfigurePlugins(env); err != nil {
-		return env, err
-	}
-
-	return env, nil
-}
-
-// ConfigurePlugins configures the loaded plugins using the provided
-// configuration variables. It doesn't consult the environment or any other
-// external source at all. This is the preferred method to use in tests.
-func (plugins *Plugins) ConfigurePlugins(env commands.Environment) error {
-	for _, trafficPluginFactory := range plugins.Factories {
-		plugin, err := trafficPluginFactory.New(env)
-		if err != nil {
-			return fmt.Errorf("Traffic plugin \"%v\" configuration error: %v", trafficPluginFactory.Name(), err)
+			return nil, fmt.Errorf("Traffic plugin \"%v\" configuration error: %v", factory.Name(), err)
 		}
 
 		if plugin == nil {
 			continue // This plugin is inactive.
 		}
 
-		plugins.Traffic = append(plugins.Traffic, plugin)
+		trafficPlugins = append(trafficPlugins, plugin)
 	}
 
-	return nil
-}
-
-func (plugins *Plugins) loadTrafficPlugin(pluginPath string, pluginAllowlist map[string]bool) error {
-	plug, err := plugin.Open(pluginPath)
-	if err != nil {
-		return err
-	}
-	symTrafficPluginFactory, err := plug.Lookup("Factory")
-	if err != nil {
-		return err
-	}
-
-	var trafficPluginFactory traffic.PluginFactory
-	trafficPluginFactory, ok := symTrafficPluginFactory.(traffic.PluginFactory)
-	if !ok {
-		return fmt.Errorf("Factory does not implement the TrafficPluginFactory interface:\n\t%v", pluginPath)
-	}
-
-	if pluginAllowlist != nil && !pluginAllowlist[trafficPluginFactory.Name()] {
-		// Skip this plugin. (Note that this isn't an error; we're just
-		// declining to load a plugin we could've loaded.)
-		logger.Printf("Skipping plugin: %s\n", trafficPluginFactory.Name())
-		return nil
-	}
-
-	logger.Printf("Loading plugin: %s\n", trafficPluginFactory.Name())
-	plugins.Factories = append(plugins.Factories, trafficPluginFactory)
-
-	return nil
-}
-
-func readSharedObjectNames(dirPath string) ([]string, error) {
-	pathInfo, err := os.Stat(dirPath)
-	results := []string{}
-	if err != nil {
-		return results, err
-	}
-	if pathInfo.IsDir() == false {
-		return results, errors.New(fmt.Sprintf("Path is not a directory %v", dirPath))
-	}
-	return filepath.Glob(path.Join(dirPath, "*.so"))
+	return trafficPlugins, nil
 }
 
 /*

--- a/relay/plugins/traffic/content-blocker-plugin/content-blocker-plugin.go
+++ b/relay/plugins/traffic/content-blocker-plugin/content-blocker-plugin.go
@@ -42,6 +42,7 @@ import (
 	"regexp"
 	"strconv"
 
+	"github.com/fullstorydev/relay-core/relay/commands"
 	"github.com/fullstorydev/relay-core/relay/plugins/traffic"
 )
 
@@ -65,16 +66,19 @@ func (f contentBlockerPluginFactory) Name() string {
 	return pluginName
 }
 
-func (f contentBlockerPluginFactory) ConfigVars() map[string]bool {
-	return map[string]bool{
-		excludeBodyContentVar:   false,
-		maskBodyContentVar:      false,
-		excludeHeaderContentVar: false,
-		maskHeaderContentVar:    false,
+func (f contentBlockerPluginFactory) New(
+	envProvider commands.EnvironmentProvider,
+) (traffic.Plugin, error) {
+	env, err := commands.GetEnvironmentOrPrintUsage(envProvider, []commands.EnvVar{
+		{EnvKey: excludeBodyContentVar},
+		{EnvKey: maskBodyContentVar},
+		{EnvKey: excludeHeaderContentVar},
+		{EnvKey: maskHeaderContentVar},
+	})
+	if err != nil {
+		return nil, err
 	}
-}
 
-func (f contentBlockerPluginFactory) New(env map[string]string) (traffic.Plugin, error) {
 	bodyBlockers, err := newContentBlockerList(
 		env,
 		"body",

--- a/relay/plugins/traffic/content-blocker-plugin/content-blocker-plugin_test.go
+++ b/relay/plugins/traffic/content-blocker-plugin/content-blocker-plugin_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/fullstorydev/relay-core/catcher"
 	"github.com/fullstorydev/relay-core/relay"
 	"github.com/fullstorydev/relay-core/relay/commands"
+	"github.com/fullstorydev/relay-core/relay/plugins/traffic"
 	"github.com/fullstorydev/relay-core/relay/plugins/traffic/content-blocker-plugin"
 	"github.com/fullstorydev/relay-core/relay/test"
 )
@@ -111,8 +112,8 @@ func TestContentBlockerBlocksWebsockets(t *testing.T) {
 	env := commands.Environment{
 		"TRAFFIC_MASK_BODY_CONTENT": `[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+`,
 	}
-	plugins := map[string]bool{
-		content_blocker_plugin.Factory.Name(): true,
+	plugins := []traffic.PluginFactory{
+		content_blocker_plugin.Factory,
 	}
 
 	test.WithCatcherAndRelay(t, env, plugins, func(catcherService *catcher.Service, relayService *relay.Service) {
@@ -155,8 +156,8 @@ type contentBlockerTestCase struct {
 }
 
 func runContentBlockerTest(t *testing.T, testCase contentBlockerTestCase) {
-	plugins := map[string]bool{
-		content_blocker_plugin.Factory.Name(): true,
+	plugins := []traffic.PluginFactory{
+		content_blocker_plugin.Factory,
 	}
 
 	originalHeaders := testCase.originalHeaders

--- a/relay/plugins/traffic/content-blocker-plugin/main/main.go
+++ b/relay/plugins/traffic/content-blocker-plugin/main/main.go
@@ -1,7 +1,0 @@
-package main
-
-import (
-	"github.com/fullstorydev/relay-core/relay/plugins/traffic/content-blocker-plugin"
-)
-
-var Factory = content_blocker_plugin.Factory

--- a/relay/plugins/traffic/interfaces.go
+++ b/relay/plugins/traffic/interfaces.go
@@ -4,41 +4,29 @@ import (
 	"log"
 	"net/http"
 	"os"
+
+	"github.com/fullstorydev/relay-core/relay/commands"
 )
 
 var logger = log.New(os.Stdout, "[relay-traffic] ", 0)
 
-// PluginFactory is the interface that the relay uses to create instances of
-// plugins from a shared object. Each shared object that exposes a relay plugin
-// must provide a public symbol named Factory that implements this interface.
-// The relay code will invoke Factory#New() to create an instance of the plugin.
+// PluginFactory is the interface that the relay uses to create plugin
+// instances.
 type PluginFactory interface {
 	// Name returns a human readable name for this plugin, like "Logging" or
 	// "Attack detector".
 	Name() string
 
-	// ConfigVars returns a map of environment variables and whether they are
-	// required by this plugin. For example, if the plugin expects environment
-	// variables  and MIN_LENGTH and can't work if MIN_LENGTH is set then the
-	// return value would be:
-	//     return map[string]bool{
-	//         "MAX_COUNT":   false,
-	//         "MIN_LENGTH":  true,
-	//     }
-	ConfigVars() map[string]bool
-
 	// New configures and returns an instance of this plugin, or an error if
-	// configuration failed.
-	//
-	// The env parameter is a map from environment variable names to their
-	// values. The map includes values from any .env file that may exist, so
-	// plugins should use it instead of reading from the environment directly.
+	// configuration failed. Configuration options are read from the given
+	// environment provider.
 	//
 	// Factories may return nil if the plugin should be inactive given the
 	// provided configuration.
-	New(env map[string]string) (Plugin, error)
+	New(envProvider commands.EnvironmentProvider) (Plugin, error)
 }
 
+// Plugin is the interface exposed by plugin instances.
 type Plugin interface {
 	// Name returns a human readable name for this plugin, like "Logging" or
 	// "Attack detector". This should match the value returned by the

--- a/relay/plugins/traffic/logging-plugin/logging-plugin.go
+++ b/relay/plugins/traffic/logging-plugin/logging-plugin.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"os"
 
+	"github.com/fullstorydev/relay-core/relay/commands"
 	"github.com/fullstorydev/relay-core/relay/plugins/traffic"
 )
 
@@ -20,11 +21,9 @@ func (f loggingPluginFactory) Name() string {
 	return pluginName
 }
 
-func (f loggingPluginFactory) ConfigVars() map[string]bool {
-	return map[string]bool{}
-}
-
-func (f loggingPluginFactory) New(env map[string]string) (traffic.Plugin, error) {
+func (f loggingPluginFactory) New(
+	envProvider commands.EnvironmentProvider,
+) (traffic.Plugin, error) {
 	return &loggingPlugin{}, nil
 }
 

--- a/relay/plugins/traffic/logging-plugin/main/main.go
+++ b/relay/plugins/traffic/logging-plugin/main/main.go
@@ -1,7 +1,0 @@
-package main
-
-import (
-	"github.com/fullstorydev/relay-core/relay/plugins/traffic/logging-plugin"
-)
-
-var Factory = logging_plugin.Factory

--- a/relay/plugins/traffic/paths-plugin/main/main.go
+++ b/relay/plugins/traffic/paths-plugin/main/main.go
@@ -1,7 +1,0 @@
-package main
-
-import (
-	"github.com/fullstorydev/relay-core/relay/plugins/traffic/paths-plugin"
-)
-
-var Factory = paths_plugin.Factory

--- a/relay/plugins/traffic/paths-plugin/paths-plugin.go
+++ b/relay/plugins/traffic/paths-plugin/paths-plugin.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"regexp"
 
+	"github.com/fullstorydev/relay-core/relay/commands"
 	"github.com/fullstorydev/relay-core/relay/plugins/traffic"
 )
 
@@ -30,14 +31,17 @@ func (f pathsPluginFactory) Name() string {
 	return pluginName
 }
 
-func (f pathsPluginFactory) ConfigVars() map[string]bool {
-	return map[string]bool{
-		matchVar:       false,
-		replacementVar: false,
+func (f pathsPluginFactory) New(
+	envProvider commands.EnvironmentProvider,
+) (traffic.Plugin, error) {
+	env, err := commands.GetEnvironmentOrPrintUsage(envProvider, []commands.EnvVar{
+		{EnvKey: matchVar},
+		{EnvKey: replacementVar},
+	})
+	if err != nil {
+		return nil, err
 	}
-}
 
-func (f pathsPluginFactory) New(env map[string]string) (traffic.Plugin, error) {
 	match := env[matchVar]
 	replacement := env[replacementVar]
 	if len(match) == 0 && len(replacement) == 0 {

--- a/relay/plugins/traffic/relay-plugin/main/main.go
+++ b/relay/plugins/traffic/relay-plugin/main/main.go
@@ -1,7 +1,0 @@
-package main
-
-import (
-	"github.com/fullstorydev/relay-core/relay/plugins/traffic/relay-plugin"
-)
-
-var Factory = relay_plugin.Factory

--- a/relay/plugins/traffic/relay-plugin/relay-plugin.go
+++ b/relay/plugins/traffic/relay-plugin/relay-plugin.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/fullstorydev/relay-core/relay/commands"
 	"github.com/fullstorydev/relay-core/relay/plugins/traffic"
 )
 
@@ -42,17 +43,23 @@ func (f relayPluginFactory) Name() string {
 	return pluginName
 }
 
-func (f relayPluginFactory) ConfigVars() map[string]bool {
-	return map[string]bool{
-		trafficRelayTargetVar:         true,
-		trafficRelaySpecials:          false,
-		trafficRelayCookiesVar:        false,
-		trafficRelayMaxBodySizeVar:    false,
-		trafficRelayOriginOverrideVar: false,
+func (f relayPluginFactory) New(
+	envProvider commands.EnvironmentProvider,
+) (traffic.Plugin, error) {
+	env, err := commands.GetEnvironmentOrPrintUsage(envProvider, []commands.EnvVar{
+		{
+			EnvKey:   trafficRelayTargetVar,
+			Required: true,
+		},
+		{EnvKey: trafficRelaySpecials},
+		{EnvKey: trafficRelayCookiesVar},
+		{EnvKey: trafficRelayMaxBodySizeVar},
+		{EnvKey: trafficRelayOriginOverrideVar},
+	})
+	if err != nil {
+		return nil, err
 	}
-}
 
-func (f relayPluginFactory) New(env map[string]string) (traffic.Plugin, error) {
 	transport := &http.Transport{
 		TLSClientConfig: &tls.Config{},
 		Proxy:           http.ProxyFromEnvironment,

--- a/relay/service.go
+++ b/relay/service.go
@@ -5,7 +5,7 @@ import (
 	"net"
 	"net/http"
 
-	"github.com/fullstorydev/relay-core/relay/plugins"
+	"github.com/fullstorydev/relay-core/relay/plugins/traffic"
 )
 
 var MonitorPath = "/__relay__up__/"
@@ -17,10 +17,9 @@ type Service struct {
 	listener       net.Listener
 	trafficService *TrafficService
 	mux            *http.ServeMux
-	plugins        *plugins.Plugins
 }
 
-func NewService(plugs *plugins.Plugins) *Service {
+func NewService(trafficPlugins []traffic.Plugin) *Service {
 	mux := http.NewServeMux()
 
 	// Write a simple page for monitoring
@@ -30,7 +29,7 @@ func NewService(plugs *plugins.Plugins) *Service {
 	})
 
 	// Handle everything else with traffic plugins
-	trafficService := NewTrafficService(plugs)
+	trafficService := NewTrafficService(trafficPlugins)
 	mux.Handle("/", trafficService)
 
 	// TODO add a control/monitoring service
@@ -38,7 +37,6 @@ func NewService(plugs *plugins.Plugins) *Service {
 	return &Service{
 		trafficService: trafficService,
 		mux:            mux,
-		plugins:        plugs,
 	}
 }
 

--- a/relay/traffic.go
+++ b/relay/traffic.go
@@ -3,25 +3,25 @@ package relay
 import (
 	"net/http"
 
-	"github.com/fullstorydev/relay-core/relay/plugins"
+	"github.com/fullstorydev/relay-core/relay/plugins/traffic"
 )
 
 /*
 TrafficService services HTTP requests by calling through to traffic plugins
 */
 type TrafficService struct {
-	plugins *plugins.Plugins
+	plugins []traffic.Plugin
 }
 
-func NewTrafficService(plugs *plugins.Plugins) *TrafficService {
+func NewTrafficService(trafficPlugins []traffic.Plugin) *TrafficService {
 	return &TrafficService{
-		plugins: plugs,
+		plugins: trafficPlugins,
 	}
 }
 
 func (service *TrafficService) ServeHTTP(response http.ResponseWriter, request *http.Request) {
 	serviced := false
-	for _, trafficPlugin := range service.plugins.Traffic {
+	for _, trafficPlugin := range service.plugins {
 		if trafficPlugin.HandleRequest(response, request, serviced) {
 			serviced = true
 		}


### PR DESCRIPTION
This PR simplifies the relay plugin architecture. It's largely a refactor that sets us up to resolve the outstanding backlog items for the relay using simpler, cleaner code.

## Changes in this PR

### Plugins are now compiled into the binary
The major change here is that we've stopped using the `plugin` package totally. Plugins still exist, but they're now built into the relay binary, instead of being loaded from external `.so` files. This gives us quite a few advantages:
* Go's `plugin` package is extremely finicky; the build environments used by a program and its plugins must be essentially identical. This means that by _far_ the easiest and most reliable way to build a working plugin is to build it along with the rest of the relay code, so in practice the procedure for building and deploying a third party plugin remains essentially the same, but the risk of folks trying to do things the "wrong way" and running into subtle issues has been eliminated.
* Plugins can now reliably share complex types and interfaces with the host application, which allows for simpler, more strongly-typed, and more natural code.
* When there are changes to the plugin interface, anyone maintaining a custom plugin will get readable compiler errors that are straightforward to fix instead of having to deal with a runtime error that provides minimal context.
* Lots of code and error handling has been removed, as well as an entire configuration option. Combined with the other changes in this PR, the plugin loading process has been simplified so much that it has been reduced to a single, simple function.
* We can now return to using alpine as our base Docker image. (See #12 for context.) This will shave ~92MB off of the Docker image size. (I'll handle this in a followup.)

### The `PluginFactory` interface has been simplified
Previously, plugins read their configuration variables using a flow like this:
1. `traffic.PluginFactory#ConfigVars()` is called for each plugin to get a list of configuration variables the plugin needs.
2. The configuration variables from each plugin are merged together.
3. `commands.GetEnvironment()` is called to read the configuration variables values from environment variables and any `.env` file that may exist. If an error is reported, `commands.PrintEnvUsage()` is called and the program exits.
4. The configuration variable values are passed each plugin's `traffic.PluginFactory#New()` to create an instance of that plugin.

This overcomplicated setup was necessary because it was finicky to pass more complex interfaces to plugins implemented using the `plugin` package. Now that that constraint has been eliminated, we can use the following more streamlined approach.
1. `traffic.PluginFactory#New()` is called for each plugin. We pass in an `EnvironmentProvider` interface instance that gives it access to its environment.
2. Internally, `traffic.PluginFactory#New()` passes the `EnvironmentProvider` to `commands.GetEnvironmentOrPrintUsage()`, allowing it to read its own configuration variables. Usage information is automatically printed if an issue is discovered, and an error is returned immediately.
3. `traffic.PluginFactory#New()` uses the configuration variable values to create a plugin instance and returns it.

Why is this better? There are several advantages:
* The overall protocol for creating a plugin instance has been greatly simplified. Combined with the other change above, this means that only a single function call is needed to load and configure plugins. This replaces a complicated set of interacting methods that previously existed essentially just to deal with configuration variables.
* By giving plugins full control over their configuration process, it becomes possible to implement support for more complex, structured ways of representing a plugin configuration, like a YAML configuration file. The previous model would've been very hard to extend to support that.
* All plugin configuration error messages are now printed in a single place - `traffic.PluginFactory#New()`. Under the previous model, missing required configuration options were the only thing that was handled in a different place, but that inconsistency has now been eliminated. In practice, the way that different kinds of error output are logged is still not completely uniform, but I held off on tackling that for now because the introduction of a configuration file will require a revamp of that functionality anyway.

## Upcoming changes

For context, here's what's coming next. (Many of these things are partially implemented already!)
* Returning to using alpine as the base Docker image, as discussed above. (This is #15.)
* Converting `relay-plugin` and `logging-plugin` into built-in code within `TrafficService`. This will simplify things further, and it will enable `relay-plugin` to invoke plugins _itself_, which will make it possible for plugins to process websocket messages. (This is #17.)
* Based on the change above, extend `content-blocker-plugin` to handle websocket messages and remove the code that blocks websockets when that plugin is used.
* Add support for a YAML configuration file to make it more convenient to configure complex plugins like `content-blocker-plugin`.
* Some general fixes and improvements to the release process of the relay Docker image. (This is #16.)
* Documentation updates to cover all of the changes that have occurred recently.