### PR TITLE
Switch Docker base image to alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,8 @@
-FROM ubuntu:22.04 AS builder
-RUN apt-get update && \
-    apt-get install -y \
-      build-essential \
-      ca-certificates \
-      golang \
-      golang-1.18
+FROM alpine:3.16 AS builder
+RUN apk add --no-cache --update \
+  alpine-sdk \
+  ca-certificates \
+  go
 ADD ./catcher ./catcher
 ADD ./relay ./relay
 ADD ./go.mod .
@@ -13,9 +11,8 @@ ADD ./Makefile .
 RUN set -ex && \
 	make
 
-FROM ubuntu:22.04
-RUN apt-get update && \
-    apt-get install -y \
-      ca-certificates
+FROM alpine:3.16
+RUN apk add --no-cache --update \
+  ca-certificates
 COPY --from=builder /dist /dist
 ENTRYPOINT [ "/dist/relay" ]


### PR DESCRIPTION
Now that #14 has eliminated the dependency on the Go `plugin` package, which was incompatible with musl, we can switch back to using an alpine base Docker image.

As a quick recap, to work around that compatibility, we switched from alpine to ubuntu in #12. This increased the size of the Docker image from 62MB to 154MB, which was a bit of a bummer.

As expected, by switching back to alpine, this PR drops the size of the Docker image, but the improvement is better than one might expect. Go tends to produce fairly large binaries, so compiling each plugin into a separate binary was really bloating the size of the image. After #14's change to compile the plugins directly into the relay binary, we've removed that bloat, so the size of the Docker image after this PR will be just _22MB_. In other words, taken together, the recent changes have reduced the overall size of the Docker image by 65%. Nice!

Edit: After a minor tweak, we're actually down to _19.6MB_ - even better!