### PR TITLE
Bump version numbers, update docs, and apply trivial pre-release fixes

### DIFF
--- a/config/dotenv.example
+++ b/config/dotenv.example
@@ -4,9 +4,6 @@
 # The port on which the relay service will listen (no default)
 RELAY_PORT=8086
 
-# The file path to the directory containing relay plugins (defaults to ./plugins)
-# RELAY_PLUGINS_PATH=./plugins
-
 # The default URL for the traffic relay plugin to target (no default)
 TRAFFIC_RELAY_TARGET=http://127.0.0.1:12346
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -1,31 +1,11 @@
 # Relay Plugins
 
-The core relay program doesn't include much functionality other than loading plugins and calling into them at appropriate times. Even the main feature of relaying is performed by a plugin!
-
-## Using plugins
-
-If you successfully build using `make` then you'll have a `relay-core/dist/plugins/traffic/` directory holding several .so files. These are the plugin files.
-
-*Load order:*
-
-Plugins are loaded in alpha-numeric sort order, which is why the default build names the plugins like so:
-
-- 010-relay.so
-- 020-monitor.so
-- 030-logging.so
-
-The order of traffic plugins matters because each plugin is given the opportunity to service incoming requests. The default order lets the relay plugin attempt to relay the request and then the monitor and logging plugins can do their work assuming that the request is handled.
-
-If you write a plugin then you'll want to name it in such a way that it is loaded in the order that you expect. For example, if you want your plugin to load between the relay and monitor plugins then you'd name it `015-something.so` and because 015 is between 010 and 020 it'll be loaded as expected.
+The core relay program's functionality can be extended using plugins. Much of the built-in functionality of the relay is implemented using these plugins, in fact. Plugins are built into the relay binary at compile time, so you don't need to do anything special to load them.
 
 ## Writing plugins
 
-Relay plugins are implemented as [go plugins](https://github.com/golang/go/wiki/Modules) and that comes with a few tricky bits. The most common error is for a plugin to not expose exactly the expected interface and then fail to load.
+To write a plugin for the relay, you need to write implementations for the [PluginFactory and Plugin interfaces](https://github.com/fullstorydev/relay-core/blob/master/relay/traffic/plugin-interfaces.go). The [built-in plugins](https://github.com/fullstorydev/relay-core/tree/master/relay/plugins/traffic) may serve as a useful starting point.
 
-There are three traffic plugins (currently the only plugin type) in the `relay-core` source code that you can use as example code for your plugin:
-- [relay](https://github.com/fullstorydev/relay-core/tree/master/go/src/relay/plugins/traffic/relay/main)
-- [monitor](https://github.com/fullstorydev/relay-core/tree/master/go/src/relay/plugins/traffic/monitor/main)
-- [logging](https://github.com/fullstorydev/relay-core/tree/master/go/src/relay/plugins/traffic/logging/main)
+Plugins are built and tested as part of the relay code, so you can simply run `make` to build your plugin or `make test` to run its tests.
 
-To build a plugin you need to use `go build -buildmode=plugin ...` which you can see used in the `plugins` target of Relay's [Makefile](https://github.com/fullstorydev/relay-core/blob/master/Makefile).
-
+To use your new plugin outside of tests, you'll also need to add it to the [DefaultPlugins list](https://github.com/fullstorydev/relay-core/blob/master/relay/main/main.go). This will make the `relay` program load the plugin at startup.

--- a/docs/running.md
+++ b/docs/running.md
@@ -16,9 +16,9 @@ Somewhat annoyingly, GitHub requires authentication in order to use even public 
 
 Once Docker is authenticated with GitHub you can pull the image in the usual way:
 
-	docker pull docker.pkg.github.com/fullstorydev/relay-core/relay-core:v0.1.2
+	docker pull docker.pkg.github.com/fullstorydev/relay-core/relay-core:v0.2.0
 
-You probably want the latest version so check for a version greater than v0.1.2.
+You probably want the latest version so check for a version greater than v0.2.0.
 
 ### Building a local Docker image
 
@@ -33,29 +33,30 @@ To create an image:
 
 Pre-built:
 
-	docker run -e "RELAY_PORT=8990" -e "RELAY_PLUGINS_PATH=/dist/plugins/" -e "TRAFFIC_RELAY_TARGET=http://127.0.0.1:12346/" --publish 8990:8990 -d docker.pkg.github.com/fullstorydev/relay-core/relay-core:v0.1.2
+	docker run -e "RELAY_PORT=8990" -e "TRAFFIC_RELAY_TARGET=http://127.0.0.1:12346/" --publish 8990:8990 -d docker.pkg.github.com/fullstorydev/relay-core/relay-core:v0.2.0
 
-(update the `v0.1.2` if you're using a different version)
+(update the `v0.2.0` if you're using a different version)
 
 Locally built:
 
-	docker run -e "RELAY_PORT=8990" -e "RELAY_PLUGINS_PATH=/dist/plugins/" -e "TRAFFIC_RELAY_TARGET=http://127.0.0.1:12346/" --publish 8990:8990 -d relay:local-v0
+	docker run -e "RELAY_PORT=8990" -e "TRAFFIC_RELAY_TARGET=http://127.0.0.1:12346/" --publish 8990:8990 -d relay:local-v0
 
 You'll want to change the various environment variables to suite your scenario, as documented in the [example dotenv file](https://github.com/fullstorydev/relay-core/blob/master/config/dotenv.example).
 
-## Using binaries
+## Local Development
 
-While we provide [pre-built 'relay' binaries](https://github.com/fullstorydev/relay-core/releases) for each version, to run the Relay you also need a specific directory hierarchy containing [plugins](plugins.md). The default build creates `relay-core/dist/` containing both binary and plugins so the easiest way to get started is:
+To build:
 
-	cd relay-core/
 	make
-	# ... build output ...
-	cd dist/
+
+To run tests:
+
+	make test
+
+To run the relay locally after a successful build:
+
+	cd dist
 	./relay
-
-If you already have a distribution directory with the correct plugins then you can drop in new, pre-built binaries as they're released.
-
-The pre-built Docker images already contain the plugins so if building is annoying then you might try the Docker route.
 
 ## Configuration
 

--- a/relay/commands/commands.go
+++ b/relay/commands/commands.go
@@ -95,15 +95,10 @@ type DefaultEnvironmentProvider struct {
 	dotEnv map[string]string
 }
 
-func NewDefaultEnvironmentProvider() (EnvironmentProvider, error) {
-	dotEnv, err := parseDotEnv(".env")
-	if err != nil {
-		return nil, err
-	}
-
+func NewDefaultEnvironmentProvider() EnvironmentProvider {
 	return &DefaultEnvironmentProvider{
-		dotEnv: dotEnv,
-	}, nil
+		dotEnv: parseDotEnv(".env"),
+	}
 }
 
 func (provider *DefaultEnvironmentProvider) Lookup(key string) (string, bool) {
@@ -120,12 +115,13 @@ func (provider *DefaultEnvironmentProvider) Lookup(key string) (string, bool) {
 	return "", false
 }
 
-func parseDotEnv(filePath string) (map[string]string, error) {
+func parseDotEnv(filePath string) map[string]string {
 	results := map[string]string{}
 
 	file, err := os.Open(filePath)
 	if err != nil {
-		return nil, err
+		// It's OK for .env to not exist.
+		return results
 	}
 	defer file.Close()
 
@@ -154,7 +150,7 @@ func parseDotEnv(filePath string) (map[string]string, error) {
 		results[key] = value
 	}
 
-	return results, nil
+	return results
 }
 
 // TestEnvironmentProvider reads environment variables from a hard-coded list.

--- a/relay/main/main.go
+++ b/relay/main/main.go
@@ -21,12 +21,7 @@ var DefaultPlugins = []traffic.PluginFactory{
 }
 
 func main() {
-	envProvider, err := commands.NewDefaultEnvironmentProvider()
-	if err != nil {
-		logger.Println(err)
-		os.Exit(1)
-	}
-
+	envProvider := commands.NewDefaultEnvironmentProvider()
 	env := commands.NewEnvironment(envProvider)
 	config, err := relay.ReadConfig(env)
 	if err != nil {

--- a/relay/plugins/traffic/content-blocker-plugin/content-blocker-plugin.go
+++ b/relay/plugins/traffic/content-blocker-plugin/content-blocker-plugin.go
@@ -52,7 +52,7 @@ var (
 	pluginName = "Content-Blocker"
 
 	PluginVersionHeaderName = "X-Relay-Content-Blocker-Version"
-	PluginVersion           = "v0.1.3"
+	PluginVersion           = "v0.2.0"
 )
 
 type contentBlockerPluginFactory struct{}

--- a/relay/traffic/handler.go
+++ b/relay/traffic/handler.go
@@ -15,7 +15,7 @@ import (
 )
 
 const RelayVersionHeaderName = "X-Relay-Version"
-const RelayVersion = "v0.1.3" // TODO set this from tags automatically during git commit
+const RelayVersion = "v0.2.0" // TODO set this from tags automatically during git commit
 
 var logger = log.New(os.Stdout, "[relay-traffic] ", 0)
 

--- a/relay/traffic/plugin-interfaces.go
+++ b/relay/traffic/plugin-interfaces.go
@@ -19,7 +19,7 @@ type PluginFactory interface {
 	//
 	// Factories may return nil if the plugin should be inactive given the
 	// provided configuration.
-	New(envProvider *commands.Environment) (Plugin, error)
+	New(env *commands.Environment) (Plugin, error)
 }
 
 // Plugin is the interface exposed by plugin instances.


### PR DESCRIPTION
This PR prepares us for the 0.2.0 release by bumping version numbers, updating docs to capture the recent changes, and fixing some super-trivial issues that emerged during testing.