### PR TITLE
Add tests for untested features and fix TRAFFIC_RELAY_COOKIES

### DIFF
--- a/relay/plugins/traffic/content-blocker-plugin/content-blocker-plugin.go
+++ b/relay/plugins/traffic/content-blocker-plugin/content-blocker-plugin.go
@@ -44,6 +44,7 @@ import (
 
 	"github.com/fullstorydev/relay-core/relay/commands"
 	"github.com/fullstorydev/relay-core/relay/traffic"
+	"github.com/fullstorydev/relay-core/relay/version"
 )
 
 var (
@@ -52,7 +53,6 @@ var (
 	pluginName = "Content-Blocker"
 
 	PluginVersionHeaderName = "X-Relay-Content-Blocker-Version"
-	PluginVersion           = "v0.2.0"
 )
 
 type contentBlockerPluginFactory struct{}
@@ -110,7 +110,7 @@ func (plug contentBlockerPlugin) HandleRequest(response http.ResponseWriter, req
 	}
 
 	// Tag the request with a header for debugging purposes.
-	request.Header.Add(PluginVersionHeaderName, PluginVersion)
+	request.Header.Add(PluginVersionHeaderName, version.RelayRelease)
 
 	return false
 }

--- a/relay/plugins/traffic/content-blocker-plugin/content-blocker-plugin_test.go
+++ b/relay/plugins/traffic/content-blocker-plugin/content-blocker-plugin_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/fullstorydev/relay-core/relay/plugins/traffic/content-blocker-plugin"
 	"github.com/fullstorydev/relay-core/relay/test"
 	"github.com/fullstorydev/relay-core/relay/traffic"
+	"github.com/fullstorydev/relay-core/relay/version"
 )
 
 func TestContentBlockerBlocksContent(t *testing.T) {
@@ -169,7 +170,7 @@ func runContentBlockerTest(t *testing.T, testCase contentBlockerTestCase) {
 		expectedHeaders = make(map[string]string)
 	}
 
-	expectedHeaders[content_blocker_plugin.PluginVersionHeaderName] = content_blocker_plugin.PluginVersion
+	expectedHeaders[content_blocker_plugin.PluginVersionHeaderName] = version.RelayRelease
 
 	test.WithCatcherAndRelay(t, testCase.env, plugins, func(catcherService *catcher.Service, relayService *relay.Service) {
 		request, err := http.NewRequest(

--- a/relay/plugins/traffic/paths-plugin/paths-plugin_test.go
+++ b/relay/plugins/traffic/paths-plugin/paths-plugin_test.go
@@ -1,0 +1,232 @@
+package paths_plugin_test
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/fullstorydev/relay-core/catcher"
+	"github.com/fullstorydev/relay-core/relay"
+	"github.com/fullstorydev/relay-core/relay/plugins/traffic/paths-plugin"
+	"github.com/fullstorydev/relay-core/relay/test"
+	"github.com/fullstorydev/relay-core/relay/traffic"
+)
+
+func TestPathRewriting(t *testing.T) {
+	testCases := []pathsPluginTestCase{
+		{
+			desc: "Basic path remapping works",
+			env: map[string]string{
+				"TRAFFIC_PATHS_MATCH":       `^/foo/`,
+				"TRAFFIC_PATHS_REPLACEMENT": `/xyz/`,
+			},
+			originalUrl: `${RELAY_HTTP_URL}/foo/bar/baz`,
+			expectedUrl: `${TARGET_HTTP_URL}/xyz/bar/baz`,
+		},
+		{
+			desc: "Paths that do not match are not changed",
+			env: map[string]string{
+				"TRAFFIC_PATHS_MATCH":       `^/foo/`,
+				"TRAFFIC_PATHS_REPLACEMENT": `/xyz/`,
+			},
+			originalUrl: `${RELAY_HTTP_URL}/abc/bar/baz`,
+			expectedUrl: `${TARGET_HTTP_URL}/abc/bar/baz`,
+		},
+		{
+			desc: "Capture groups can be used",
+			env: map[string]string{
+				"TRAFFIC_PATHS_MATCH":       `^/([^/]*)/foo/([^/]*)/bar/`,
+				"TRAFFIC_PATHS_REPLACEMENT": `/$1/xyz/$2/abc/`,
+			},
+			originalUrl: `${RELAY_HTTP_URL}/apple/foo/banana/bar/carrot`,
+			expectedUrl: `${TARGET_HTTP_URL}/apple/xyz/banana/abc/carrot`,
+		},
+		{
+			desc: "Query params are preserved",
+			env: map[string]string{
+				"TRAFFIC_PATHS_MATCH":       `^/foo/`,
+				"TRAFFIC_PATHS_REPLACEMENT": `/xyz/`,
+			},
+			originalUrl: `${RELAY_HTTP_URL}/foo/bar/baz?x=y&abc=123`,
+			expectedUrl: `${TARGET_HTTP_URL}/xyz/bar/baz?x=y&abc=123`,
+		},
+		{
+			desc: "Matching and replacement only affect the path",
+			env: map[string]string{
+				"TRAFFIC_PATHS_MATCH":       `foo`,
+				"TRAFFIC_PATHS_REPLACEMENT": `xyz`,
+			},
+			originalUrl: `${RELAY_HTTP_URL}/foo/bar/baz?x=y&foo=123`,
+			expectedUrl: `${TARGET_HTTP_URL}/xyz/bar/baz?x=y&foo=123`,
+		},
+	}
+
+	for _, testCase := range testCases {
+		runPathsPluginTest(t, testCase)
+	}
+}
+
+func TestSpecialPaths(t *testing.T) {
+	testCases := []pathsPluginTestCase{
+		{
+			desc: "Basic path remapping works",
+			env: map[string]string{
+				"TRAFFIC_RELAY_SPECIALS": `^/foo/ ${ALT_TARGET_HTTP_URL}/xyz/`,
+			},
+			originalUrl: `${RELAY_HTTP_URL}/foo/bar/baz`,
+			expectedUrl: `${ALT_TARGET_HTTP_URL}/xyz/bar/baz`,
+		},
+		{
+			desc: "Paths that do not match are not changed",
+			env: map[string]string{
+				"TRAFFIC_RELAY_SPECIALS": `^/foo/ ${ALT_TARGET_HTTP_URL}/xyz/`,
+			},
+			originalUrl: `${RELAY_HTTP_URL}/abc/bar/baz`,
+			expectedUrl: `${TARGET_HTTP_URL}/abc/bar/baz`,
+		},
+		{
+			desc: "Capture groups can be used",
+			env: map[string]string{
+				"TRAFFIC_RELAY_SPECIALS": `^/([^/]*)/foo/([^/]*)/bar/ ${ALT_TARGET_HTTP_URL}/$1/xyz/$2/abc/`,
+			},
+			originalUrl: `${RELAY_HTTP_URL}/apple/foo/banana/bar/carrot`,
+			expectedUrl: `${ALT_TARGET_HTTP_URL}/apple/xyz/banana/abc/carrot`,
+		},
+		{
+			desc: "Query params are preserved",
+			env: map[string]string{
+				"TRAFFIC_RELAY_SPECIALS": `^/foo/ ${ALT_TARGET_HTTP_URL}/xyz/`,
+			},
+			originalUrl: `${RELAY_HTTP_URL}/foo/bar/baz?x=y&abc=123`,
+			expectedUrl: `${ALT_TARGET_HTTP_URL}/xyz/bar/baz?x=y&abc=123`,
+		},
+		{
+			desc: "Matching and replacement only affect the path",
+			env: map[string]string{
+				"TRAFFIC_RELAY_SPECIALS": `^/foo/ ${ALT_TARGET_HTTP_URL}/xyz/`,
+			},
+			originalUrl: `${RELAY_HTTP_URL}/foo/bar/baz?x=y&foo=123`,
+			expectedUrl: `${ALT_TARGET_HTTP_URL}/xyz/bar/baz?x=y&foo=123`,
+		},
+		{
+			desc: "Multiple rules can be used at once (part 1)",
+			env: map[string]string{
+				"TRAFFIC_RELAY_SPECIALS": `^/apple/ ${ALT_TARGET_HTTP_URL}/xyz/ ^/banana/ ${ALT_TARGET_HTTP_URL}/abc/`,
+			},
+			originalUrl: `${RELAY_HTTP_URL}/apple/foo/bar`,
+			expectedUrl: `${ALT_TARGET_HTTP_URL}/xyz/foo/bar`,
+		},
+		{
+			desc: "Multiple rules can be used at once (part 2)",
+			env: map[string]string{
+				"TRAFFIC_RELAY_SPECIALS": `^/apple/ ${ALT_TARGET_HTTP_URL}/xyz/ ^/banana/ ${ALT_TARGET_HTTP_URL}/abc/`,
+			},
+			originalUrl: `${RELAY_HTTP_URL}/banana/foo/bar`,
+			expectedUrl: `${ALT_TARGET_HTTP_URL}/abc/foo/bar`,
+		},
+	}
+
+	for _, testCase := range testCases {
+		runPathsPluginTest(t, testCase)
+	}
+}
+
+type pathsPluginTestCase struct {
+	desc        string
+	env         map[string]string
+	originalUrl string
+	expectedUrl string
+}
+
+func runPathsPluginTest(t *testing.T, testCase pathsPluginTestCase) {
+	plugins := []traffic.PluginFactory{
+		paths_plugin.Factory,
+	}
+
+	// Start our own instance of the catcher service. This allows us to provide
+	// an alternative target for test cases to redirect to.
+	altCatcherService := catcher.NewService()
+	if err := altCatcherService.Start("localhost", 0); err != nil {
+		t.Errorf("Error starting alternative catcher: %v", err)
+		return
+	}
+	defer altCatcherService.Close()
+
+	// Substitute ALT_TARGET_HTTP_URL into the environment variables so it can
+	// be used in TRAFFIC_RELAY_SPECIALS.
+	env := map[string]string{}
+	for envVar, value := range testCase.env {
+		env[envVar] = strings.Replace(value, "${ALT_TARGET_HTTP_URL}", altCatcherService.HttpUrl(), -1)
+	}
+
+	test.WithCatcherAndRelay(t, env, plugins, func(catcherService *catcher.Service, relayService *relay.Service) {
+		// Substitute RELAY_HTTP_URL and TARGET_HTTP_URL into the URLs. We
+		// unfortunately can't combine this with the environment variable
+		// substitution because we only have access to these values once the
+		// relay has started up, but at that point the plugins have already been
+		// configured and changes to environment variable values would have no
+		// effect.
+		varReplacer := strings.NewReplacer(
+			"${ALT_TARGET_HTTP_URL}", altCatcherService.HttpUrl(),
+			"${RELAY_HTTP_URL}", relayService.HttpUrl(),
+			"${TARGET_HTTP_URL}", catcherService.HttpUrl(),
+		)
+		originalUrl := varReplacer.Replace(testCase.originalUrl)
+		expectedUrl := varReplacer.Replace(testCase.expectedUrl)
+
+		response, err := http.Get(originalUrl)
+		if err != nil {
+			t.Errorf("Error GETing: %v", err)
+			return
+		}
+		defer response.Body.Close()
+
+		if response.StatusCode != 200 {
+			t.Errorf("Test '%v': Expected 200 response: %v", testCase.desc, response)
+			return
+		}
+
+		lastRequest, err := catcherService.LastRequest()
+		if err != nil {
+			lastRequest, err = altCatcherService.LastRequest()
+		}
+		if err != nil {
+			t.Errorf("Error reading last request from catcher: %v", err)
+			return
+		}
+
+		// The value of lastRequest.URL is relative; convert it to an absolute URL.
+		actualUrl := *lastRequest.URL
+		actualUrl.Scheme = "http"
+		actualUrl.Host = lastRequest.Host
+
+		if actualUrl.String() != expectedUrl {
+			t.Errorf(
+				"Test '%v': Expected URL '%v' to become '%v' but got: %v",
+				testCase.desc,
+				originalUrl,
+				expectedUrl,
+				actualUrl.String(),
+			)
+		}
+	})
+}
+
+/*
+Copyright 2022 FullStory, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+and associated documentation files (the "Software"), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge, publish, distribute,
+sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or
+substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/

--- a/relay/plugins/traffic/test-interceptor-plugin/test-interceptor-plugin.go
+++ b/relay/plugins/traffic/test-interceptor-plugin/test-interceptor-plugin.go
@@ -1,0 +1,73 @@
+package test_interceptor_plugin
+
+// The TestInterceptor plugin offers a hook that allows tests to observe the
+// requests received by the relay. In production, this plugin is not useful.
+
+import (
+	"log"
+	"net/http"
+	"os"
+
+	"github.com/fullstorydev/relay-core/relay/commands"
+	"github.com/fullstorydev/relay-core/relay/traffic"
+)
+
+var (
+	Factory    testInterceptorPluginFactory
+	logger     = log.New(os.Stdout, "[traffic-test-interceptor] ", 0)
+	pluginName = "TestInterceptor"
+)
+
+type HandleRequestListener func(request *http.Request)
+
+func NewFactoryWithListener(listener HandleRequestListener) traffic.PluginFactory {
+	return testInterceptorPluginFactory{
+		listener: listener,
+	}
+}
+
+type testInterceptorPluginFactory struct {
+	listener HandleRequestListener
+}
+
+func (f testInterceptorPluginFactory) Name() string {
+	return pluginName
+}
+
+func (f testInterceptorPluginFactory) New(env *commands.Environment) (traffic.Plugin, error) {
+	return &testInterceptorPlugin{
+		listener: f.listener,
+	}, nil
+}
+
+type testInterceptorPlugin struct {
+	listener HandleRequestListener
+}
+
+func (plug testInterceptorPlugin) Name() string {
+	return pluginName
+}
+
+func (plug testInterceptorPlugin) HandleRequest(response http.ResponseWriter, request *http.Request, serviced bool) bool {
+	plug.listener(request)
+	return false
+}
+
+/*
+Copyright 2022 FullStory, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+and associated documentation files (the "Software"), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge, publish, distribute,
+sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or
+substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/

--- a/relay/traffic/handler.go
+++ b/relay/traffic/handler.go
@@ -12,10 +12,11 @@ import (
 	"os"
 	"strings"
 	"time"
+
+	"github.com/fullstorydev/relay-core/relay/version"
 )
 
 const RelayVersionHeaderName = "X-Relay-Version"
-const RelayVersion = "v0.2.0" // TODO set this from tags automatically during git commit
 
 var logger = log.New(os.Stdout, "[relay-traffic] ", 0)
 
@@ -111,7 +112,7 @@ func (handler *Handler) prepRelayRequest(clientRequest *http.Request) {
 				continue
 			}
 			if first == false {
-				cookieString.WriteString("&")
+				cookieString.WriteString("; ")
 			}
 			cookieString.WriteString(cookie.String())
 			first = false
@@ -128,7 +129,7 @@ func (handler *Handler) prepRelayRequest(clientRequest *http.Request) {
 	clientRequest.Header.Add("X-Forwarded-Proto", strings.ToLower(strings.Split(clientRequest.Proto, "/")[0]))
 
 	// Add X-Relay-Version header
-	clientRequest.Header.Add(RelayVersionHeaderName, RelayVersion)
+	clientRequest.Header.Add(RelayVersionHeaderName, version.RelayRelease)
 }
 
 func (handler *Handler) handleHttp(clientResponse http.ResponseWriter, clientRequest *http.Request) bool {

--- a/relay/traffic/traffic_test.go
+++ b/relay/traffic/traffic_test.go
@@ -6,12 +6,16 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"reflect"
 	"strings"
 	"testing"
 
 	"github.com/fullstorydev/relay-core/catcher"
 	"github.com/fullstorydev/relay-core/relay"
+	"github.com/fullstorydev/relay-core/relay/plugins/traffic/test-interceptor-plugin"
 	"github.com/fullstorydev/relay-core/relay/test"
+	"github.com/fullstorydev/relay-core/relay/traffic"
+	"github.com/fullstorydev/relay-core/relay/version"
 	"golang.org/x/net/websocket"
 )
 
@@ -34,31 +38,193 @@ func TestBasicRelay(t *testing.T) {
 	})
 }
 
-func TestOriginOverride(t *testing.T) {
-	newOrigin := "example.com"
-	env := map[string]string{
-		"TRAFFIC_RELAY_ORIGIN_OVERRIDE": newOrigin,
+func TestRelayedCookies(t *testing.T) {
+	testCases := []struct {
+		desc                  string
+		env                   map[string]string
+		originalCookieHeaders []string
+		expectedCookieHeaders []string
+	}{
+		{
+			desc:                  "No cookies are relayed by default",
+			env:                   map[string]string{},
+			originalCookieHeaders: []string{"SPECIAL_ID=298zf09hf012fh2; token=u32t4o3tb3gg43", "_gat=1"},
+			expectedCookieHeaders: nil,
+		},
+		{
+			desc: "Multiple Cookie headers are merged",
+			env: map[string]string{
+				"TRAFFIC_RELAY_COOKIES": "SPECIAL_ID token _gat",
+			},
+			originalCookieHeaders: []string{"SPECIAL_ID=298zf09hf012fh2; token=u32t4o3tb3gg43", "_gat=1"},
+			expectedCookieHeaders: []string{"SPECIAL_ID=298zf09hf012fh2; token=u32t4o3tb3gg43; _gat=1"},
+		},
+		{
+			desc: "Only allowlisted cookies are relayed",
+			env: map[string]string{
+				"TRAFFIC_RELAY_COOKIES": "SPECIAL_ID foo _gat",
+			},
+			originalCookieHeaders: []string{"SPECIAL_ID=298zf09hf012fh2; token=u32t4o3tb3gg43; foo=bar", "_gat=1; bar=foo"},
+			expectedCookieHeaders: []string{"SPECIAL_ID=298zf09hf012fh2; foo=bar; _gat=1"},
+		},
+		{
+			desc: "A Cookie header is dropped entirely when no cookies match",
+			env: map[string]string{
+				"TRAFFIC_RELAY_COOKIES": "bar",
+			},
+			originalCookieHeaders: []string{"SPECIAL_ID=298zf09hf012fh2; token=u32t4o3tb3gg43; foo=bar", "_gat=1; bar=foo"},
+			expectedCookieHeaders: []string{"bar=foo"},
+		},
 	}
 
-	test.WithCatcherAndRelay(t, env, nil, func(catcherService *catcher.Service, relayService *relay.Service) {
-		_, err := http.Get(relayService.HttpUrl())
-		if err != nil {
-			t.Errorf("Error GETing: %v", err)
-			return
+	for _, testCase := range testCases {
+		test.WithCatcherAndRelay(t, testCase.env, nil, func(catcherService *catcher.Service, relayService *relay.Service) {
+			request, err := http.NewRequest("GET", relayService.HttpUrl(), nil)
+			if err != nil {
+				t.Errorf("Test '%v': Error creating request: %v", testCase.desc, err)
+				return
+			}
+
+			for _, cookieHeaderValue := range testCase.originalCookieHeaders {
+				request.Header.Add("Cookie", cookieHeaderValue)
+			}
+
+			response, err := http.DefaultClient.Do(request)
+			if err != nil {
+				t.Errorf("Test '%v': Error GETing: %v", testCase.desc, err)
+				return
+			}
+			defer response.Body.Close()
+
+			if response.StatusCode != 200 {
+				t.Errorf("Test '%v': Expected 200 response: %v", testCase.desc, response)
+				return
+			}
+
+			lastRequest, err := catcherService.LastRequest()
+			if err != nil {
+				t.Errorf("Test '%v': Error reading last request from catcher: %v", testCase.desc, err)
+				return
+			}
+
+			actualCookieHeaders := lastRequest.Header["Cookie"]
+			if !reflect.DeepEqual(testCase.expectedCookieHeaders, actualCookieHeaders) {
+				t.Errorf(
+					"Test '%v': Expected Cookie header values '%v' but got '%v'",
+					testCase.desc,
+					testCase.expectedCookieHeaders,
+					actualCookieHeaders,
+				)
+			}
+		})
+	}
+}
+
+func TestRelayedHeaders(t *testing.T) {
+	testCases := []struct {
+		desc            string
+		env             map[string]string
+		originalHeaders map[string]string
+		expectedHeaders map[string]string
+	}{
+		{
+			desc: "Headers are relayed by default",
+			env:  map[string]string{},
+			originalHeaders: map[string]string{
+				"Accept-Encoding": "deflate, gzip;q=1.0, *;q=0.5",
+				"Downlink":        "100",
+				"Origin":          "https://test.com",
+				"Viewport-Width":  "100",
+			},
+			expectedHeaders: map[string]string{
+				"Accept-Encoding": "deflate, gzip;q=1.0, *;q=0.5",
+				"Downlink":        "100",
+				"Origin":          "https://test.com",
+				"Viewport-Width":  "100",
+			},
+		},
+		{
+			desc: "Overriding the Origin header works",
+			env: map[string]string{
+				"TRAFFIC_RELAY_ORIGIN_OVERRIDE": "example.com",
+			},
+			originalHeaders: map[string]string{
+				"Accept-Encoding": "deflate, gzip;q=1.0, *;q=0.5",
+				"Downlink":        "100",
+				"Origin":          "https://test.com",
+				"Viewport-Width":  "100",
+			},
+			expectedHeaders: map[string]string{
+				"Accept-Encoding": "deflate, gzip;q=1.0, *;q=0.5",
+				"Downlink":        "100",
+				"Origin":          "http://example.com",
+				"Viewport-Width":  "100",
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		var lastClientIP, lastClientPort string
+
+		plugins := []traffic.PluginFactory{
+			test_interceptor_plugin.NewFactoryWithListener(func(request *http.Request) {
+				// Capture the actual IP and port used in the request.
+				addrComponents := strings.Split(request.RemoteAddr, ":")
+				lastClientIP = addrComponents[0]
+				lastClientPort = addrComponents[1]
+			}),
 		}
 
-		lastRequest, err := catcherService.LastRequest()
-		if err != nil {
-			t.Errorf("Error reading last request from catcher: %v", err)
-			return
-		}
+		test.WithCatcherAndRelay(t, testCase.env, plugins, func(catcherService *catcher.Service, relayService *relay.Service) {
+			request, err := http.NewRequest("GET", relayService.HttpUrl(), nil)
+			if err != nil {
+				t.Errorf("Test '%v': Error creating request: %v", testCase.desc, err)
+				return
+			}
 
-		lastRequestOrigin := lastRequest.Header.Get("Origin")
-		if "http://"+newOrigin != lastRequestOrigin {
-			t.Errorf("Origin override mismatch: \"%v\" \"%v\"", newOrigin, lastRequestOrigin)
-			return
-		}
-	})
+			for headerName, headerValue := range testCase.originalHeaders {
+				request.Header.Add(headerName, headerValue)
+			}
+
+			response, err := http.DefaultClient.Do(request)
+			if err != nil {
+				t.Errorf("Test '%v': Error GETing: %v", testCase.desc, err)
+				return
+			}
+			defer response.Body.Close()
+
+			if response.StatusCode != 200 {
+				t.Errorf("Test '%v': Expected 200 response: %v", testCase.desc, response)
+				return
+			}
+
+			lastRequest, err := catcherService.LastRequest()
+			if err != nil {
+				t.Errorf("Test '%v': Error reading last request from catcher: %v", testCase.desc, err)
+				return
+			}
+
+			// Check for the built-in headers that the relay always generates.
+			testCase.expectedHeaders["X-Forwarded-Proto"] = "http"
+			testCase.expectedHeaders[traffic.RelayVersionHeaderName] = version.RelayRelease
+			testCase.expectedHeaders["X-Forwarded-For"] = lastClientIP
+			testCase.expectedHeaders["X-Forwarded-Port"] = lastClientPort
+
+			for headerName, expectedHeaderValue := range testCase.expectedHeaders {
+				expectedHeaderValues := []string{expectedHeaderValue}
+				actualHeaderValues := lastRequest.Header[headerName]
+				if !reflect.DeepEqual(expectedHeaderValues, actualHeaderValues) {
+					t.Errorf(
+						"Test '%v': Expected '%v' header values '%v' but got '%v'",
+						testCase.desc,
+						headerName,
+						expectedHeaderValues,
+						actualHeaderValues,
+					)
+				}
+			}
+		})
+	}
 }
 
 func TestMaxBodySize(t *testing.T) {

--- a/relay/version/version.go
+++ b/relay/version/version.go
@@ -1,0 +1,3 @@
+package version
+
+const RelayRelease = "v0.2.0" // TODO set this from tags automatically during git commit


### PR DESCRIPTION
This PR adds tests for a number of features that don't currently have any tests, including:
* TRAFFIC_PATHS_MATCH/TRAFFIC_PATHS_REPLACEMENT
* TRAFFIC_RELAY_SPECIALS
* TRAFFIC_RELAY_COOKIES

In addition, I've added testing for the relay's behavior with respect to headers, including that headers like `X-Forwarded-For` are correctly generated.

These tests immediately made it clear that `TRAFFIC_RELAY_COOKIES` does not construct a syntactically correct `Cookie` header; this PR includes a fix.

To assist in adding the tests, I also made some supporting changes:
* There's now a `TestInterceptor` plugin that allows tests to listen in on requests to the relay.
* The version number of the relay has now been moved to its own package. This allows us to update only a single place when it's time to make a new release. It's in its own package to ensure that it can be imported from anywhere without circular import issues.