### PR TITLE
Pull most configurable functions into plugins

### DIFF
--- a/relay/main/main.go
+++ b/relay/main/main.go
@@ -7,18 +7,10 @@ import (
 
 	"github.com/fullstorydev/relay-core/relay"
 	"github.com/fullstorydev/relay-core/relay/commands"
-	"github.com/fullstorydev/relay-core/relay/plugins/traffic/content-blocker-plugin"
-	"github.com/fullstorydev/relay-core/relay/plugins/traffic/paths-plugin"
-	"github.com/fullstorydev/relay-core/relay/traffic"
+	"github.com/fullstorydev/relay-core/relay/traffic/plugin-loader"
 )
 
 var logger = log.New(os.Stdout, "[relay] ", 0)
-
-// The default set of traffic plugins.
-var DefaultPlugins = []traffic.PluginFactory{
-	paths_plugin.Factory,
-	content_blocker_plugin.Factory,
-}
 
 func main() {
 	envProvider := commands.NewDefaultEnvironmentProvider()
@@ -29,7 +21,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	trafficPlugins, err := traffic.LoadPlugins(DefaultPlugins, env)
+	trafficPlugins, err := plugin_loader.Load(plugin_loader.DefaultPlugins, env)
 	if err != nil {
 		logger.Println(err)
 		os.Exit(1)

--- a/relay/plugins/traffic/content-blocker-plugin/content-blocker-plugin.go
+++ b/relay/plugins/traffic/content-blocker-plugin/content-blocker-plugin.go
@@ -101,7 +101,15 @@ func (plug contentBlockerPlugin) Name() string {
 	return pluginName
 }
 
-func (plug contentBlockerPlugin) HandleRequest(response http.ResponseWriter, request *http.Request, serviced bool) bool {
+func (plug contentBlockerPlugin) HandleRequest(
+	response http.ResponseWriter,
+	request *http.Request,
+	info traffic.RequestInfo,
+) bool {
+	if info.Serviced {
+		return false
+	}
+
 	if serviced := plug.blockHeaderContent(response, request); serviced {
 		return true
 	}

--- a/relay/plugins/traffic/cookies-plugin/cookies-plugin.go
+++ b/relay/plugins/traffic/cookies-plugin/cookies-plugin.go
@@ -1,0 +1,106 @@
+package cookies_plugin
+
+// The Cookies plugin provides the capability to allowlist cookies on incoming
+// requests. By default, all cookies are blocked. This is because in the context
+// of the relay, cookies are quite high-risk; it usually runs in a first-party
+// context, so the risk of receiving cookies that were intended for another
+// service is substantial.
+
+import (
+	"log"
+	"net/http"
+	"os"
+	"strings"
+
+	"github.com/fullstorydev/relay-core/relay/commands"
+	"github.com/fullstorydev/relay-core/relay/traffic"
+)
+
+var (
+	Factory    cookiesPluginFactory
+	logger     = log.New(os.Stdout, "[traffic-cookies] ", 0)
+	pluginName = "Cookies"
+)
+
+type cookiesPluginFactory struct{}
+
+func (f cookiesPluginFactory) Name() string {
+	return pluginName
+}
+
+func (f cookiesPluginFactory) New(env *commands.Environment) (traffic.Plugin, error) {
+	plugin := &cookiesPlugin{
+		allowlist: map[string]bool{},
+	}
+
+	if cookiesVal, ok := env.LookupOptional("TRAFFIC_RELAY_COOKIES"); ok {
+		for _, cookieName := range strings.Split(cookiesVal, " ") {
+			logger.Printf(`Cookies plugin will allowlist cookie "%s"`, cookieName)
+			plugin.allowlist[cookieName] = true
+		}
+	}
+
+	if len(plugin.allowlist) == 0 {
+		return nil, nil
+	}
+
+	return plugin, nil
+}
+
+type cookiesPlugin struct {
+	allowlist map[string]bool // The name of cookies that should be relayed.
+}
+
+func (plug cookiesPlugin) Name() string {
+	return pluginName
+}
+
+func (plug cookiesPlugin) HandleRequest(
+	response http.ResponseWriter,
+	request *http.Request,
+	info traffic.RequestInfo,
+) bool {
+	if info.Serviced {
+		return false
+	}
+
+	// Restore the original Cookie header so that we can parse it using the
+	// methods on http.Request.
+	for _, headerValue := range info.OriginalCookieHeaders {
+		request.Header.Add("Cookie", headerValue)
+	}
+
+	// Parse the Cookie header and filter out cookies which aren't present in
+	// the allowlist.
+	var cookies []string
+	for _, cookie := range request.Cookies() {
+		if !plug.allowlist[cookie.Name] {
+			continue
+		}
+		cookies = append(cookies, cookie.String())
+	}
+
+	// Reserialize the Cookie header.
+	request.Header.Set("Cookie", strings.Join(cookies, "; "))
+
+	return false
+}
+
+/*
+Copyright 2022 FullStory, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+and associated documentation files (the "Software"), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge, publish, distribute,
+sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or
+substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/

--- a/relay/plugins/traffic/cookies-plugin/cookies-plugin_test.go
+++ b/relay/plugins/traffic/cookies-plugin/cookies-plugin_test.go
@@ -1,0 +1,118 @@
+package cookies_plugin_test
+
+import (
+	"net/http"
+	"reflect"
+	"testing"
+
+	"github.com/fullstorydev/relay-core/catcher"
+	"github.com/fullstorydev/relay-core/relay"
+	"github.com/fullstorydev/relay-core/relay/plugins/traffic/cookies-plugin"
+	"github.com/fullstorydev/relay-core/relay/test"
+	"github.com/fullstorydev/relay-core/relay/traffic"
+)
+
+func TestRelayedCookies(t *testing.T) {
+	testCases := []struct {
+		desc                  string
+		env                   map[string]string
+		originalCookieHeaders []string
+		expectedCookieHeaders []string
+	}{
+		{
+			desc:                  "No cookies are relayed by default",
+			env:                   map[string]string{},
+			originalCookieHeaders: []string{"SPECIAL_ID=298zf09hf012fh2; token=u32t4o3tb3gg43", "_gat=1"},
+			expectedCookieHeaders: nil,
+		},
+		{
+			desc: "Multiple Cookie headers are merged",
+			env: map[string]string{
+				"TRAFFIC_RELAY_COOKIES": "SPECIAL_ID token _gat",
+			},
+			originalCookieHeaders: []string{"SPECIAL_ID=298zf09hf012fh2; token=u32t4o3tb3gg43", "_gat=1"},
+			expectedCookieHeaders: []string{"SPECIAL_ID=298zf09hf012fh2; token=u32t4o3tb3gg43; _gat=1"},
+		},
+		{
+			desc: "Only allowlisted cookies are relayed",
+			env: map[string]string{
+				"TRAFFIC_RELAY_COOKIES": "SPECIAL_ID foo _gat",
+			},
+			originalCookieHeaders: []string{"SPECIAL_ID=298zf09hf012fh2; token=u32t4o3tb3gg43; foo=bar", "_gat=1; bar=foo"},
+			expectedCookieHeaders: []string{"SPECIAL_ID=298zf09hf012fh2; foo=bar; _gat=1"},
+		},
+		{
+			desc: "A Cookie header is dropped entirely when no cookies match",
+			env: map[string]string{
+				"TRAFFIC_RELAY_COOKIES": "bar",
+			},
+			originalCookieHeaders: []string{"SPECIAL_ID=298zf09hf012fh2; token=u32t4o3tb3gg43; foo=bar", "_gat=1; bar=foo"},
+			expectedCookieHeaders: []string{"bar=foo"},
+		},
+	}
+
+	plugins := []traffic.PluginFactory{
+		cookies_plugin.Factory,
+	}
+
+	for _, testCase := range testCases {
+		test.WithCatcherAndRelay(t, testCase.env, plugins, func(catcherService *catcher.Service, relayService *relay.Service) {
+			request, err := http.NewRequest("GET", relayService.HttpUrl(), nil)
+			if err != nil {
+				t.Errorf("Test '%v': Error creating request: %v", testCase.desc, err)
+				return
+			}
+
+			for _, cookieHeaderValue := range testCase.originalCookieHeaders {
+				request.Header.Add("Cookie", cookieHeaderValue)
+			}
+
+			response, err := http.DefaultClient.Do(request)
+			if err != nil {
+				t.Errorf("Test '%v': Error GETing: %v", testCase.desc, err)
+				return
+			}
+			defer response.Body.Close()
+
+			if response.StatusCode != 200 {
+				t.Errorf("Test '%v': Expected 200 response: %v", testCase.desc, response)
+				return
+			}
+
+			lastRequest, err := catcherService.LastRequest()
+			if err != nil {
+				t.Errorf("Test '%v': Error reading last request from catcher: %v", testCase.desc, err)
+				return
+			}
+
+			actualCookieHeaders := lastRequest.Header["Cookie"]
+			if !reflect.DeepEqual(testCase.expectedCookieHeaders, actualCookieHeaders) {
+				t.Errorf(
+					"Test '%v': Expected Cookie header values '%v' but got '%v'",
+					testCase.desc,
+					testCase.expectedCookieHeaders,
+					actualCookieHeaders,
+				)
+			}
+		})
+	}
+}
+
+/*
+Copyright 2022 FullStory, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+and associated documentation files (the "Software"), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge, publish, distribute,
+sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or
+substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/

--- a/relay/plugins/traffic/headers-plugin/headers-plugin_test.go
+++ b/relay/plugins/traffic/headers-plugin/headers-plugin_test.go
@@ -1,0 +1,126 @@
+package headers_plugin_test
+
+import (
+	"net/http"
+	"reflect"
+	"testing"
+
+	"github.com/fullstorydev/relay-core/catcher"
+	"github.com/fullstorydev/relay-core/relay"
+	"github.com/fullstorydev/relay-core/relay/plugins/traffic/headers-plugin"
+	"github.com/fullstorydev/relay-core/relay/test"
+	"github.com/fullstorydev/relay-core/relay/traffic"
+)
+
+func TestHeadersPlugin(t *testing.T) {
+	testCases := []struct {
+		desc            string
+		env             map[string]string
+		originalHeaders map[string]string
+		expectedHeaders map[string]string
+	}{
+		{
+			desc: "The Origin header is relayed unchanged by default",
+			env:  map[string]string{},
+			originalHeaders: map[string]string{
+				"Accept-Encoding": "deflate, gzip;q=1.0, *;q=0.5",
+				"Downlink":        "100",
+				"Origin":          "https://test.com",
+				"Viewport-Width":  "100",
+			},
+			expectedHeaders: map[string]string{
+				"Accept-Encoding": "deflate, gzip;q=1.0, *;q=0.5",
+				"Downlink":        "100",
+				"Origin":          "https://test.com",
+				"Viewport-Width":  "100",
+			},
+		},
+		{
+			desc: "Overriding the Origin header works",
+			env: map[string]string{
+				"TRAFFIC_RELAY_ORIGIN_OVERRIDE": "example.com",
+			},
+			originalHeaders: map[string]string{
+				"Accept-Encoding": "deflate, gzip;q=1.0, *;q=0.5",
+				"Downlink":        "100",
+				"Origin":          "https://test.com",
+				"Viewport-Width":  "100",
+			},
+			expectedHeaders: map[string]string{
+				"Accept-Encoding": "deflate, gzip;q=1.0, *;q=0.5",
+				"Downlink":        "100",
+				"Origin":          "http://example.com",
+				"Viewport-Width":  "100",
+			},
+		},
+	}
+
+	plugins := []traffic.PluginFactory{
+		headers_plugin.Factory,
+	}
+
+	for _, testCase := range testCases {
+		test.WithCatcherAndRelay(t, testCase.env, plugins, func(catcherService *catcher.Service, relayService *relay.Service) {
+			request, err := http.NewRequest("GET", relayService.HttpUrl(), nil)
+			if err != nil {
+				t.Errorf("Test '%v': Error creating request: %v", testCase.desc, err)
+				return
+			}
+
+			for headerName, headerValue := range testCase.originalHeaders {
+				request.Header.Add(headerName, headerValue)
+			}
+
+			response, err := http.DefaultClient.Do(request)
+			if err != nil {
+				t.Errorf("Test '%v': Error GETing: %v", testCase.desc, err)
+				return
+			}
+			defer response.Body.Close()
+
+			if response.StatusCode != 200 {
+				t.Errorf("Test '%v': Expected 200 response: %v", testCase.desc, response)
+				return
+			}
+
+			lastRequest, err := catcherService.LastRequest()
+			if err != nil {
+				t.Errorf("Test '%v': Error reading last request from catcher: %v", testCase.desc, err)
+				return
+			}
+
+			for headerName, expectedHeaderValue := range testCase.expectedHeaders {
+				expectedHeaderValues := []string{expectedHeaderValue}
+				actualHeaderValues := lastRequest.Header[headerName]
+				if !reflect.DeepEqual(expectedHeaderValues, actualHeaderValues) {
+					t.Errorf(
+						"Test '%v': Expected '%v' header values '%v' but got '%v'",
+						testCase.desc,
+						headerName,
+						expectedHeaderValues,
+						actualHeaderValues,
+					)
+				}
+			}
+		})
+	}
+}
+
+/*
+Copyright 2022 FullStory, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+and associated documentation files (the "Software"), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge, publish, distribute,
+sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or
+substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/

--- a/relay/test/util.go
+++ b/relay/test/util.go
@@ -7,6 +7,7 @@ import (
 	"github.com/fullstorydev/relay-core/relay"
 	"github.com/fullstorydev/relay-core/relay/commands"
 	"github.com/fullstorydev/relay-core/relay/traffic"
+	"github.com/fullstorydev/relay-core/relay/traffic/plugin-loader"
 )
 
 // WithCatcherAndRelay is a helper function that wraps the setup and teardown
@@ -61,7 +62,7 @@ func setupRelay(
 		return nil, err
 	}
 
-	trafficPlugins, err := traffic.LoadPlugins(pluginFactories, env)
+	trafficPlugins, err := plugin_loader.Load(pluginFactories, env)
 	if err != nil {
 		return nil, err
 	}

--- a/relay/traffic/config.go
+++ b/relay/traffic/config.go
@@ -1,26 +1,15 @@
 package traffic
 
-import "regexp"
-
 type RelayConfig struct {
-	MaxBodySize    int64           // Maximum length in bytes of relayed bodies.
-	OriginOverride string          // Default to passing Origin header as-is, but set to override.
-	RelayedCookies map[string]bool // The name of cookies that should be relayed.
-	SpecialPaths   []SpecialPath   // Path patterns that are mapped to fully qualified URLs.
-	TargetHost     string          // The host to relay traffic to. (e.g. 192.168.0.1:1234)
-	TargetScheme   string          // The scheme ('http' or 'https') to use to communicate with the target host.
-}
-
-type SpecialPath struct {
-	Match       *regexp.Regexp
-	Replacement string
+	MaxBodySize  int64  // Maximum length in bytes of relayed bodies.
+	TargetHost   string // The host to relay traffic to. (e.g. 192.168.0.1:1234)
+	TargetScheme string // The scheme ('http' or 'https') to use to communicate with the target host.
 }
 
 const DefaultMaxBodySize int64 = 1024 * 2048 // 2MB
 
 func NewDefaultRelayConfig() *RelayConfig {
 	return &RelayConfig{
-		MaxBodySize:    DefaultMaxBodySize,
-		RelayedCookies: map[string]bool{},
+		MaxBodySize: DefaultMaxBodySize,
 	}
 }

--- a/relay/traffic/plugin-interfaces.go
+++ b/relay/traffic/plugin-interfaces.go
@@ -2,6 +2,7 @@ package traffic
 
 import (
 	"net/http"
+	"net/url"
 
 	"github.com/fullstorydev/relay-core/relay/commands"
 )
@@ -33,13 +34,30 @@ type Plugin interface {
 	// HTTP request.
 	//
 	// Plugins may ignore an incoming request, alter it in some way, or service
-	// the request and return a response to the client. If the 'serviced'
-	// parameter is true, a previous plugin has already responded to the
-	// request.
+	// the request and return a response to the client.
 	//
 	// HandleRequest should return true if a response has been sent to the
 	// client.
-	HandleRequest(response http.ResponseWriter, request *http.Request, serviced bool) bool
+	HandleRequest(
+		response http.ResponseWriter,
+		request *http.Request,
+		requestInfo RequestInfo,
+	) bool
+}
+
+// RequestInfo provides additional information about incoming requests.
+type RequestInfo struct {
+	// The original cookie headers included in the client request. For security
+	// and privacy reasons, these are automatically removed from the client
+	// request before plugins get an opportunity to handle it.
+	OriginalCookieHeaders []string
+
+	// The original URL requested by the client, before any redirection by the
+	// relay.
+	OriginalURL *url.URL
+
+	// If true, a response has already been sent to the client.
+	Serviced bool
 }
 
 /*

--- a/relay/traffic/plugin-loader/registry.go
+++ b/relay/traffic/plugin-loader/registry.go
@@ -1,0 +1,27 @@
+package plugin_loader
+
+import (
+	"github.com/fullstorydev/relay-core/relay/plugins/traffic/content-blocker-plugin"
+	"github.com/fullstorydev/relay-core/relay/plugins/traffic/cookies-plugin"
+	"github.com/fullstorydev/relay-core/relay/plugins/traffic/headers-plugin"
+	"github.com/fullstorydev/relay-core/relay/plugins/traffic/paths-plugin"
+	"github.com/fullstorydev/relay-core/relay/plugins/traffic/test-interceptor-plugin"
+	"github.com/fullstorydev/relay-core/relay/traffic"
+)
+
+// DefaultPlugins is a plugin registry containing all traffic plugins that
+// should be available in production. These are the plugins that the relay loads
+// on startup.
+var DefaultPlugins = []traffic.PluginFactory{
+	content_blocker_plugin.Factory,
+	cookies_plugin.Factory,
+	headers_plugin.Factory,
+	paths_plugin.Factory,
+}
+
+// TestPlugins is a plugin registry containing test-only traffic plugins. These
+// are not loaded by the relay on startup, but can be loaded programmatically in
+// tests.
+var TestPlugins = []traffic.PluginFactory{
+	test_interceptor_plugin.Factory,
+}


### PR DESCRIPTION
This PR contains the final round of refactoring I wanted to get knocked out before adding support for a YAML configuration file. Most configurable functionality exposed by the core relay code has now been moved into plugins. In addition to the existing Paths plugin, which has been expanded, there are now Cookies and Headers plugins as well. This has a few advantages:
* The core relay code has been simplified.
* The new code is more modular. The new plugins are easier to test in isolation.
* Any new functionality related to one of these areas now has a natural home, and it can be added without disturbing the core functionality of the relay.
* The YAML configuration file will expose one YAML object per plugin, so having the functionality organized in this way will lead to a clean-feeling configuration file as well.

Although this PR touches a lot of lines, it's mostly just refactoring, thankfully supported by the much more comprehensive set of tests that's in place now. I'll call out some particular changes of interest below.