### PR TITLE
Adding ReadHeaderTimeout to prevent Slowloris DoS

### DIFF
--- a/relay/service.go
+++ b/relay/service.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"time"
 
 	"github.com/fullstorydev/relay-core/relay/traffic"
 )
@@ -75,8 +76,9 @@ func (service *Service) Port() int {
 func (service *Service) Start(host string, port int) error {
 	address := fmt.Sprintf("%v:%v", host, port)
 	server := &http.Server{
-		Addr:    address,
-		Handler: service.mux,
+		Addr:              address,
+		Handler:           service.mux,
+		ReadHeaderTimeout: 2 * time.Second,
 	}
 	listener, err := net.Listen("tcp", address)
 	if err != nil {

--- a/relay/version/version.go
+++ b/relay/version/version.go
@@ -1,3 +1,3 @@
 package version
 
-const RelayRelease = "v0.3.0" // TODO set this from tags automatically during git commit
+const RelayRelease = "v0.3.1" // TODO set this from tags automatically during git commit


### PR DESCRIPTION
In order to prevent a Slowloris DoS attack (a good overview of Slowloris is documented [here](https://medium.com/a-journey-with-go/go-understand-and-mitigate-slowloris-attack-711c1b1403f6)), add a `ReadHeaderTimeout` timeout value of 2 seconds. This is the same value set as the `IdleConnTimeout` in the traffic handler.