### PR TITLE
Suppresse relay error for 0 content-length responses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /dist
 
 /.vscode
+/.idea

--- a/relay/traffic/handler.go
+++ b/relay/traffic/handler.go
@@ -137,7 +137,9 @@ func (handler *Handler) handleHttp(clientResponse http.ResponseWriter, clientReq
 	} else if targetResponse.ContentLength < 0 {
 		clientResponse.WriteHeader(targetResponse.StatusCode)
 		if _, err := io.CopyN(clientResponse, targetResponse.Body, handler.config.MaxBodySize); err != nil {
-			logger.Printf("Error relaying response body with unknown content-length: %s", err)
+			// NOTE: it is highly likely the server would come back without a content-length especially with
+			// mobile traffic. In this case, full copy happens but we get an EOF error that can be safely
+			// ignored. See this example: https://go.dev/play/p/8T3kbRfk_vO
 		}
 	} else {
 		clientResponse.WriteHeader(targetResponse.StatusCode)

--- a/relay/traffic/handler.go
+++ b/relay/traffic/handler.go
@@ -3,6 +3,7 @@ package traffic
 import (
 	"bytes"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -139,7 +140,10 @@ func (handler *Handler) handleHttp(clientResponse http.ResponseWriter, clientReq
 		if _, err := io.CopyN(clientResponse, targetResponse.Body, handler.config.MaxBodySize); err != nil {
 			// NOTE: it is highly likely the server would come back without a content-length especially with
 			// mobile traffic. In this case, full copy happens but we get an EOF error that can be safely
-			// ignored. See this example: https://go.dev/play/p/8T3kbRfk_vO
+			// ignored. See this example: https://go.dev/play/p/xotsgkwhJis
+			if !errors.Is(err, io.EOF) {
+				logger.Printf("Error relaying response body with unknown content-length: %s", err)
+			}
 		}
 	} else {
 		clientResponse.WriteHeader(targetResponse.StatusCode)


### PR DESCRIPTION
This seems to be a non-issue since the body gets fully copied as long as it doesn't _exceed_ the maximum length.

In this code block, I believe we are in the realm of bundle responses which should be quite small.

TODO: is there a cleaner way to do this?

Fixes #29