### PR TITLE
Support scrubbing gzip encoded bundles

### DIFF
--- a/catcher/catcher.go
+++ b/catcher/catcher.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"net"
 	"net/http"
@@ -82,7 +81,7 @@ func (service *Service) LastRequestBody() ([]byte, error) {
 	}
 
 	defer request.Body.Close()
-	body, err := ioutil.ReadAll(request.Body)
+	body, err := io.ReadAll(request.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/relay/main/main.go
+++ b/relay/main/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"flag"
-	"io/ioutil"
+	"io"
 	"log"
 	"os"
 	"time"
@@ -10,14 +10,14 @@ import (
 	"github.com/fullstorydev/relay-core/relay"
 	"github.com/fullstorydev/relay-core/relay/config"
 	"github.com/fullstorydev/relay-core/relay/environment"
-	"github.com/fullstorydev/relay-core/relay/traffic/plugin-loader"
+	plugin_loader "github.com/fullstorydev/relay-core/relay/traffic/plugin-loader"
 )
 
 var logger = log.New(os.Stdout, "[relay] ", 0)
 
 func readConfigFile(path string) (rawConfigFileBytes []byte, err error) {
 	if path == "-" {
-		rawConfigFileBytes, err = ioutil.ReadAll(os.Stdin)
+		rawConfigFileBytes, err = io.ReadAll(os.Stdin)
 		return
 	}
 

--- a/relay/plugins/traffic/content-blocker-plugin/content-blocker-plugin_test.go
+++ b/relay/plugins/traffic/content-blocker-plugin/content-blocker-plugin_test.go
@@ -2,16 +2,24 @@ package content_blocker_plugin_test
 
 import (
 	"bytes"
+	"fmt"
 	"net/http"
 	"strconv"
 	"testing"
 
 	"github.com/fullstorydev/relay-core/catcher"
 	"github.com/fullstorydev/relay-core/relay"
-	"github.com/fullstorydev/relay-core/relay/plugins/traffic/content-blocker-plugin"
+	content_blocker_plugin "github.com/fullstorydev/relay-core/relay/plugins/traffic/content-blocker-plugin"
 	"github.com/fullstorydev/relay-core/relay/test"
 	"github.com/fullstorydev/relay-core/relay/traffic"
 	"github.com/fullstorydev/relay-core/relay/version"
+)
+
+type Encoding int
+
+const (
+	Identity Encoding = iota
+	Gzip
 )
 
 func TestContentBlocking(t *testing.T) {
@@ -133,7 +141,8 @@ func TestContentBlocking(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		runContentBlockerTest(t, testCase)
+		runContentBlockerTest(t, testCase, Identity)
+		runContentBlockerTest(t, testCase, Gzip)
 	}
 }
 
@@ -185,7 +194,18 @@ type contentBlockerTestCase struct {
 	expectedHeaders map[string]string
 }
 
-func runContentBlockerTest(t *testing.T, testCase contentBlockerTestCase) {
+func runContentBlockerTest(t *testing.T, testCase contentBlockerTestCase, encoding Encoding) {
+	var encodingStr string
+	switch encoding {
+	case Gzip:
+		encodingStr = "gzip"
+	case Identity:
+		encodingStr = ""
+	}
+
+	// Add encoding to the test description
+	desc := fmt.Sprintf("%s (encoding: %v)", testCase.desc, encodingStr)
+
 	plugins := []traffic.PluginFactory{
 		content_blocker_plugin.Factory,
 	}
@@ -203,14 +223,24 @@ func runContentBlockerTest(t *testing.T, testCase contentBlockerTestCase) {
 	expectedHeaders[content_blocker_plugin.PluginVersionHeaderName] = version.RelayRelease
 
 	test.WithCatcherAndRelay(t, testCase.config, plugins, func(catcherService *catcher.Service, relayService *relay.Service) {
+		b, err := traffic.EncodeData([]byte(testCase.originalBody), encodingStr)
+		if err != nil {
+			t.Errorf("Test '%v': Error encoding data: %v", desc, err)
+			return
+		}
+
 		request, err := http.NewRequest(
 			"POST",
 			relayService.HttpUrl(),
-			bytes.NewBufferString(testCase.originalBody),
+			bytes.NewBuffer(b),
 		)
 		if err != nil {
-			t.Errorf("Test '%v': Error creating request: %v", testCase.desc, err)
+			t.Errorf("Test '%v': Error creating request: %v", desc, err)
 			return
+		}
+
+		if encoding == Gzip {
+			request.Header.Set("Content-Encoding", "gzip")
 		}
 
 		request.Header.Set("Content-Type", "application/json")
@@ -220,19 +250,19 @@ func runContentBlockerTest(t *testing.T, testCase contentBlockerTestCase) {
 
 		response, err := http.DefaultClient.Do(request)
 		if err != nil {
-			t.Errorf("Test '%v': Error POSTing: %v", testCase.desc, err)
+			t.Errorf("Test '%v': Error POSTing: %v", desc, err)
 			return
 		}
 		defer response.Body.Close()
 
 		if response.StatusCode != 200 {
-			t.Errorf("Test '%v': Expected 200 response: %v", testCase.desc, response)
+			t.Errorf("Test '%v': Expected 200 response: %v", desc, response)
 			return
 		}
 
 		lastRequest, err := catcherService.LastRequest()
 		if err != nil {
-			t.Errorf("Test '%v': Error reading last request from catcher: %v", testCase.desc, err)
+			t.Errorf("Test '%v': Error reading last request from catcher: %v", desc, err)
 			return
 		}
 
@@ -241,7 +271,7 @@ func runContentBlockerTest(t *testing.T, testCase contentBlockerTestCase) {
 			if expectedHeaderValue != actualHeaderValue {
 				t.Errorf(
 					"Test '%v': Expected header '%v' with value '%v' but got: %v",
-					testCase.desc,
+					desc,
 					expectedHeader,
 					expectedHeaderValue,
 					actualHeaderValue,
@@ -249,34 +279,49 @@ func runContentBlockerTest(t *testing.T, testCase contentBlockerTestCase) {
 			}
 		}
 
-		lastRequestBody, err := catcherService.LastRequestBody()
-		if err != nil {
-			t.Errorf("Test '%v': Error reading last request body from catcher: %v", testCase.desc, err)
-			return
+		if lastRequest.Header.Get("Content-Encoding") != encodingStr {
+			t.Errorf(
+				"Test '%v': Expected Content-Encoding '%v' but got: %v",
+				desc,
+				encodingStr,
+				lastRequest.Header.Get("Content-Encoding"),
+			)
 		}
 
-		lastRequestBodyStr := string(lastRequestBody)
-		if testCase.expectedBody != lastRequestBodyStr {
-			t.Errorf(
-				"Test '%v': Expected body '%v' but got: %v",
-				testCase.desc,
-				testCase.expectedBody,
-				lastRequestBodyStr,
-			)
+		lastRequestBody, err := catcherService.LastRequestBody()
+		if err != nil {
+			t.Errorf("Test '%v': Error reading last request body from catcher: %v", desc, err)
+			return
 		}
 
 		contentLength, err := strconv.Atoi(lastRequest.Header.Get("Content-Length"))
 		if err != nil {
-			t.Errorf("Test '%v': Error parsing Content-Length: %v", testCase.desc, err)
+			t.Errorf("Test '%v': Error parsing Content-Length: %v", desc, err)
 			return
 		}
 
 		if contentLength != len(lastRequestBody) {
 			t.Errorf(
 				"Test '%v': Content-Length is %v but actual body length is %v",
-				testCase.desc,
+				desc,
 				contentLength,
 				len(lastRequestBody),
+			)
+		}
+
+		decodedRequestBody, err := traffic.DecodeData(lastRequestBody, encodingStr)
+		if err != nil {
+			t.Errorf("Test '%v': Error decoding data: %v", desc, err)
+			return
+		}
+
+		lastRequestBodyStr := string(decodedRequestBody)
+		if testCase.expectedBody != lastRequestBodyStr {
+			t.Errorf(
+				"Test '%v': Expected body '%v' but got: %v",
+				desc,
+				testCase.expectedBody,
+				lastRequestBodyStr,
 			)
 		}
 	})

--- a/relay/plugins/traffic/paths-plugin/paths-plugin_test.go
+++ b/relay/plugins/traffic/paths-plugin/paths-plugin_test.go
@@ -279,7 +279,7 @@ func runPathsPluginTest(t *testing.T, testCase pathsPluginTestCase) {
 			lastRequest, err = altCatcherService.LastRequest()
 		}
 		if err != nil {
-			t.Errorf("Error reading last request from catcher: %v", err)
+			t.Errorf("Text '%v': Error reading last request from catcher: %v", testCase.desc, err)
 			return
 		}
 

--- a/relay/traffic/encoding.go
+++ b/relay/traffic/encoding.go
@@ -47,8 +47,7 @@ func GetContentEncoding(request *http.Request) (Encoding, error) {
 	}
 }
 
-// WrapReader checks if the request Content-Encoding or request query parameter indicates gzip compression.
-// If so, it returns a gzip.Reader that decompresses the content.
+// WrapReader returns a wrapped request.Body for the encoding provided.
 func WrapReader(request *http.Request, encoding Encoding) (io.ReadCloser, error) {
 	if request.Body == nil {
 		return nil, nil

--- a/relay/traffic/encoding.go
+++ b/relay/traffic/encoding.go
@@ -1,0 +1,92 @@
+package traffic
+
+import (
+	"bytes"
+	"compress/gzip"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+func GetContentEncoding(request *http.Request) (string, error) {
+	// NOTE: This is a workaround for a bug in post-Go 1.17. See golang.org/issue/25192.
+	// Our algorithm differs from the logic of AllowQuerySemicolons by replacing semicolons with encoded semicolons instead
+	// of with ampersands. This is because we want to preserve the original query string as much as possible.
+	if strings.Contains(request.URL.RawQuery, ";") {
+		request.URL.RawQuery = strings.ReplaceAll(request.URL.RawQuery, ";", "%3B") // Replace semicolons with encoded semicolons.
+	}
+
+	queryParams, err := url.ParseQuery(request.URL.RawQuery)
+	if err != nil {
+		return "", err
+	}
+
+	// request query parameter takes precedence over request header
+	encoding := queryParams.Get("ContentEncoding")
+	if encoding == "" {
+		encoding = request.Header.Get("Content-Encoding")
+	}
+	return encoding, nil
+}
+
+// WrapReader checks if the request Content-Encoding or request query parameter indicates gzip compression.
+// If so, it returns a gzip.Reader that decompresses the content.
+func WrapReader(request *http.Request, encoding string) (io.ReadCloser, error) {
+	if request.Body == nil {
+		return nil, nil
+	}
+
+	switch encoding {
+	case "gzip":
+		// Create a new gzip.Reader to decompress the request body
+		return gzip.NewReader(request.Body)
+	default:
+		// If the content is not gzip-compressed, return the original request body
+		return request.Body, nil
+	}
+}
+
+func EncodeData(data []byte, encoding string) ([]byte, error) {
+	switch encoding {
+	case "gzip":
+		var buf bytes.Buffer
+		gz := gzip.NewWriter(&buf)
+
+		_, err := gz.Write(data)
+		if err != nil {
+			return nil, err
+		}
+
+		err = gz.Close()
+		if err != nil {
+			return nil, err
+		}
+
+		compressedData := buf.Bytes()
+		return compressedData, nil
+	default:
+		// identity encoding
+		return data, nil
+	}
+}
+
+func DecodeData(data []byte, encoding string) ([]byte, error) {
+	switch encoding {
+	case "gzip":
+		reader, err := gzip.NewReader(bytes.NewReader(data))
+		if err != nil {
+			return nil, err
+		}
+
+		decodedData, err := io.ReadAll(reader)
+		if err != nil {
+			return nil, err
+		}
+
+		return decodedData, nil
+	default:
+		// identity encoding
+		return data, nil
+	}
+}

--- a/relay/traffic/handler.go
+++ b/relay/traffic/handler.go
@@ -124,6 +124,8 @@ func (handler *Handler) HandleRequest(clientResponse http.ResponseWriter, client
 	}
 }
 
+// ensureBodyContentEncoding operates on the assumption that the downstream proxy target will be using the same
+// encoding as what the relay received and ensures we proxy the content encoded correctly.
 func (handler *Handler) ensureBodyContentEncoding(clientRequest *http.Request, encoding Encoding) {
 	switch encoding {
 	case Unsupported:

--- a/relay/traffic/handler.go
+++ b/relay/traffic/handler.go
@@ -60,7 +60,7 @@ func (handler *Handler) ServeHTTP(response http.ResponseWriter, request *http.Re
 
 	encoding, err := GetContentEncoding(request)
 	if err != nil {
-		logger.Printf("URL %v error in request content encoding: %v", request.URL, err)
+		http.Error(response, fmt.Sprintf("URL %v error in request content encoding: %v", request.URL, err), 500)
 		request.Body = http.NoBody
 		return
 	}

--- a/relay/traffic/traffic_test.go
+++ b/relay/traffic/traffic_test.go
@@ -151,33 +151,26 @@ func TestMaxBodySize(t *testing.T) {
 	})
 }
 
-type Encoding int
-
-const (
-	Identity Encoding = iota
-	Gzip
-)
-
 func TestRelaySupportsContentEncoding(t *testing.T) {
 	testCases := map[string]struct {
-		encoding       Encoding
+		encoding       traffic.Encoding
 		bodyContentStr string
 		headers        map[string]string
 		customUrl      func(relayServiceURL string) string
 	}{
 		"identity": {
-			encoding:       Identity,
+			encoding:       traffic.Identity,
 			bodyContentStr: "Hello, world!",
 		},
 		"gzip - with header": {
-			encoding:       Gzip,
+			encoding:       traffic.Gzip,
 			bodyContentStr: "Hello, world!",
 			headers: map[string]string{
 				"Content-Encoding": "gzip",
 			},
 		},
 		"gzip - with query param": {
-			encoding:       Gzip,
+			encoding:       traffic.Gzip,
 			bodyContentStr: "Hello, world!",
 			customUrl: func(relayServiceURL string) string {
 				return fmt.Sprintf("%v?ContentEncoding=gzip", relayServiceURL)
@@ -190,14 +183,14 @@ func TestRelaySupportsContentEncoding(t *testing.T) {
 			// convert the body content to a reader with the proper content encoding applied
 			var body io.Reader
 			switch testCase.encoding {
-			case Gzip:
-				b, err := traffic.EncodeData([]byte(testCase.bodyContentStr), "gzip")
+			case traffic.Gzip:
+				b, err := traffic.EncodeData([]byte(testCase.bodyContentStr), traffic.Gzip)
 				if err != nil {
 					t.Errorf("Test %s - Error encoding data: %v", desc, err)
 					return
 				}
 				body = bytes.NewReader(b)
-			case Identity:
+			case traffic.Identity:
 				body = strings.NewReader(testCase.bodyContentStr)
 			}
 
@@ -235,8 +228,8 @@ func TestRelaySupportsContentEncoding(t *testing.T) {
 			}
 
 			switch testCase.encoding {
-			case Gzip:
-				decodedData, err := traffic.DecodeData(lastRequest, "gzip")
+			case traffic.Gzip:
+				decodedData, err := traffic.DecodeData(lastRequest, traffic.Gzip)
 				if err != nil {
 					t.Errorf("Test %s - Error decoding data: %v", desc, err)
 					return
@@ -244,7 +237,7 @@ func TestRelaySupportsContentEncoding(t *testing.T) {
 				if string(decodedData) != testCase.bodyContentStr {
 					t.Errorf("Test %s - Expected body '%v' but got: %v", desc, testCase.bodyContentStr, string(decodedData))
 				}
-			case Identity:
+			case traffic.Identity:
 				if string(lastRequest) != testCase.bodyContentStr {
 					t.Errorf("Test %s - Expected body '%v' but got: %v", desc, testCase.bodyContentStr, string(lastRequest))
 				}

--- a/relay/traffic/traffic_test.go
+++ b/relay/traffic/traffic_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"reflect"
 	"strings"
@@ -12,7 +12,7 @@ import (
 
 	"github.com/fullstorydev/relay-core/catcher"
 	"github.com/fullstorydev/relay-core/relay"
-	"github.com/fullstorydev/relay-core/relay/plugins/traffic/test-interceptor-plugin"
+	test_interceptor_plugin "github.com/fullstorydev/relay-core/relay/plugins/traffic/test-interceptor-plugin"
 	"github.com/fullstorydev/relay-core/relay/test"
 	"github.com/fullstorydev/relay-core/relay/traffic"
 	"github.com/fullstorydev/relay-core/relay/version"
@@ -214,7 +214,7 @@ func getBody(url string, t *testing.T) []byte {
 		t.Errorf("Non-200 GET: %v", response)
 		return nil
 	}
-	body, err := ioutil.ReadAll(response.Body)
+	body, err := io.ReadAll(response.Body)
 	if err != nil {
 		t.Errorf("Error GETing body: %v", err)
 		return nil

--- a/relay/version/version.go
+++ b/relay/version/version.go
@@ -1,3 +1,3 @@
 package version
 
-const RelayRelease = "v0.3.2" // TODO set this from tags automatically during git commit
+const RelayRelease = "v0.3.3" // TODO set this from tags automatically during git commit


### PR DESCRIPTION
FullStory is rolling out gzip compression on the data sent from the client via `/rec/bundle`. This PR ensures that the plugin behaviour of scrubbing PII within Relay is preserved.