### PR TITLE
Bump golang net dependency due to CVE-2023-44487

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,6 @@ module github.com/fullstorydev/relay-core
 go 1.20
 
 require (
-	golang.org/x/net v0.8.0
+	golang.org/x/net v0.20.0
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 golang.org/x/net v0.8.0 h1:Zrh2ngAOFYneWTAIAPethzeaQLuHwhuBkuV6ZiRnUaQ=
 golang.org/x/net v0.8.0/go.mod h1:QVkue5JL9kW//ek3r6jTKnTFis1tRmNAW2P1shuFdJc=
+golang.org/x/net v0.20.0 h1:aCL9BSgETF1k+blQaYUBx9hJ9LOGP3gAVemcZlf1Kpo=
+golang.org/x/net v0.20.0/go.mod h1:z8BVo6PvndSri0LbOE3hAn0apkU+1YvI6E70E9jsnvY=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/relay/version/version.go
+++ b/relay/version/version.go
@@ -1,3 +1,3 @@
 package version
 
-const RelayRelease = "v0.3.1" // TODO set this from tags automatically during git commit
+const RelayRelease = "v0.3.2" // TODO set this from tags automatically during git commit


### PR DESCRIPTION
Previous PR (https://github.com/fullstorydev/relay-core/pull/38) did not retarget after base branch got merged. Reopening